### PR TITLE
Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /var/www/html
 
 VOLUME /config
 
-RUN ln -sf /config/settings.ini.php /var/www/html/settings.ini.php
+RUN ln -s /config/settings.ini.php /var/www/html/settings.ini.php
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,20 @@
 FROM php:7.0-apache
 
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git \
 
-RUN git clone https://github.com/mescon/Muximux /var/www/html
+git clone https://github.com/mescon/Muximux /var/www/html \
+
+# cleanup
+apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
 WORKDIR /var/www/html
 
 EXPOSE 80
+VOLUME /config
+RUN ln -sf /config/settings.ini.php /var/www/html/settings.ini.php
+
+
+
+
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM php:7.0-apache
 
-RUN apt-get update && apt-get install -y git \
-
-git clone https://github.com/mescon/Muximux /var/www/html \
+RUN apt-get update && apt-get install -y git && \
+git clone https://github.com/mescon/Muximux /var/www/html  && \
 
 # cleanup
-apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* 
+
 
 WORKDIR /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,14 @@ git clone https://github.com/mescon/Muximux /var/www/html  && \
 # cleanup
 apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* 
 
-
 WORKDIR /var/www/html
 
-EXPOSE 80
 VOLUME /config
+
 RUN ln -sf /config/settings.ini.php /var/www/html/settings.ini.php
+
+EXPOSE 80
+
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ WORKDIR /var/www/html
 
 VOLUME /config
 
-RUN ln -s /config/settings.ini.php /var/www/html/settings.ini.php
+RUN ln -sf /config/settings.ini.php /var/www/html/settings.ini.php
 
 EXPOSE 80
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,26 @@ With Muximux you don't need to keep multiple tabs open, or bookmark the URL to a
 
 1. Install [Docker](https://www.docker.com/)
 
+2. Make directory to store Muximux config files. Navigate to that directory and download the sample config.
+```bash
+mkdir muximux
+cd muximux
+wget https://raw.githubusercontent.com/mescon/Muximux/master/settings.ini.php-example
+```
 2. Run the container, pointing to the directory with the config file. This should now pull the image from Docker hub:
 ```bash
 docker run -d -p 80:80 \
---name="Muximux" \
+--name="muximux" \
 --restart="always" \
+--v settings.ini.php-example:/config \
 nathanthegr8/muximux
 ```
-## Port Conflicts
+
+# Config File
+```--v settings.ini.php-example:/config \```
+That is the relaitve path to the file assuming your are in the same directory as it. If you are not adjsut the relative path or use and absoulte path.
+
+# Port Conflicts
 If you run into a port conflict trying to run on 80, it is simple to modify the port forwarding:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ With Muximux you don't need to keep multiple tabs open, or bookmark the URL to a
 2. Make directory to store Muximux config files. Navigate to that directory and download the sample config.
 ```bash
 mkdir muximux
+curl -O https://raw.githubusercontent.com/mescon/Muximux/master/settings.ini.php-example muximux/settings.ini.php
 cd muximux
-curl -O https://raw.githubusercontent.com/mescon/Muximux/master/settings.ini.php-example settings.ini.php-example
 ```
 2. Run the container, pointing to the directory with the config file. This should now pull the image from Docker hub:
 ```bash
 docker run -d -p 80:80 \
 --name="muximux" \
+-v $(pwd):/config \
 --restart="always" \
--v settings.ini.php-example:/config \
 nathanthegr8/muximux
 ```
 
 # Config File
-```--v settings.ini.php-example:/config \```
-That is the relaitve path to the file assuming your are in the same directory as it. If you are not adjsut the relative path or use and absoulte path.
+```-v $(pwd):/config \```
+That will give the absoulte path to your muximux folder. It will be linked to your config in the contatiner so that if you need to rebuild the container you will retain your configuration.
 
 # Port Conflicts
 If you run into a port conflict trying to run on 80, it is simple to modify the port forwarding:

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ With Muximux you don't need to keep multiple tabs open, or bookmark the URL to a
 ```bash
 mkdir muximux
 cd muximux
-wget https://raw.githubusercontent.com/mescon/Muximux/master/settings.ini.php-example
+curl -O https://raw.githubusercontent.com/mescon/Muximux/master/settings.ini.php-example settings.ini.php-example
 ```
 2. Run the container, pointing to the directory with the config file. This should now pull the image from Docker hub:
 ```bash
 docker run -d -p 80:80 \
 --name="muximux" \
 --restart="always" \
---v settings.ini.php-example:/config \
+-v settings.ini.php-example:/config \
 nathanthegr8/muximux
 ```
 


### PR DESCRIPTION
#72 
@mescon The [linuxserver](https://github.com/linuxserver/docker-muximux) docker image doesn't work. It fails out when it is trying to modify the permissions of a file. This seems to be some sort of long running [issue](https://github.com/docker/docker/issues/6047) with docker. It seems like it was solved?, but I don't really understand the thread.
```
*** Running /etc/my_init.d/40_copy_config.sh...
chown: changing ownership of ‘/config/www/muximux/.git/objects/pack/pack-75a8cd6854f76c54f2db5720361e91b56704e310.idx’: Permission denied
chown: changing ownership of ‘/config/www/muximux/.git/objects/pack/pack-75a8cd6854f76c54f2db5720361e91b56704e310.pack’: Permission denied
*** /etc/my_init.d/40_copy_config.sh failed with status 1
2016-08-22T20:03:57.345429834Z 
*** Killing all processes...
```
I was working on my own docker file that incorporated the config as a mounted volume and sym linked to the root of the web directory. However I am running in to a problem. The image builds fine but the sym link doesn't seem to exist when I go to check. It looks like in your muximux.php write_ini() function you are saving over the existing file. I am not sure how to change this to preserver the symlink.