### PR TITLE
Feature/mobilemenufix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -290,6 +290,14 @@ Main components
     box-shadow: -9px 10px 13px -2px rgba(0, 0, 0, 0.3);
 }
 
+@media screen and (max-width:800px) {
+    .drop-nav {
+    max-height: 400px;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    }
+}
+
 .drop-nav li {
     border-bottom: 1px solid rgba(255, 255, 255, .2);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -104,13 +104,7 @@ jQuery(document).ready(function ($) {
     jQuery.fn.reverse = [].reverse;
 
      // Move items to the dropdown on mobile devices
-    var isMobile = false;
-    if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|ipad|iris|kindle|Android|Silk|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i.test(navigator.userAgent)
-    || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(navigator.userAgent.substr(0,4))) isMobile = true;
-
-    if (isMobile) {
-        $('.cd-tabs-navigation nav').children().appendTo(".drop-nav");
-    }
+    muximuxMobileResize();
 
     settingsEventHandlers();
     scaleFrames();
@@ -142,3 +136,18 @@ $(window).unload(function() {
         type: 'GET'
     });
 });
+
+$( window ).resize(muximuxMobileResize);
+
+function muximuxMobileResize() {
+    if($( window ).width() < 800) {
+        // isMobile = true;
+        $('.cd-tabs-navigation nav').children().appendTo(".drop-nav");
+        var menuHeight = $( window ).height() * .80;
+        $('.drop-nav').css('max-height', menuHeight+'px');
+    } else {
+        // isMobile = false;
+        $(".drop-nav").children('.cd-tab').appendTo('.cd-tabs-navigation nav');
+        $('.drop-nav').css('max-height', '');
+    }
+}

--- a/muximux.php
+++ b/muximux.php
@@ -200,9 +200,9 @@ function menuItems()
 
         if (!empty($section["enabled"]) && !($section["enabled"] == "false") && ($section["enabled"] == "true") && (!isset($section["dd"]) || $section["dd"] == "false")) {
             if (!empty($section["default"]) && !($section["default"] == "false") && ($section["default"] == "true")) {
-                $standardmenu .= "<li><a data-content=\"" . $keyname . "\" data-title=\"" . $section["name"] . "\" class=\"selected\"><span class=\"fa " . $section["icon"] . " fa-lg\"></span> " . $section["name"] . "</a></li>\n";
+                $standardmenu .= "<li class='cd-tab'><a data-content=\"" . $keyname . "\" data-title=\"" . $section["name"] . "\" class=\"selected\"><span class=\"fa " . $section["icon"] . " fa-lg\"></span> " . $section["name"] . "</a></li>\n";
             } else {
-                $standardmenu .= "<li><a data-content=\"" . $keyname . "\" data-title=\"" . $section["name"] . "\"><span class=\"fa " . $section["icon"] . " fa-lg\"></span> " . $section["name"] . "</a></li>\n";
+                $standardmenu .= "<li class='cd-tab'><a data-content=\"" . $keyname . "\" data-title=\"" . $section["name"] . "\"><span class=\"fa " . $section["icon"] . " fa-lg\"></span> " . $section["name"] . "</a></li>\n";
             }
         }
         if (isset($section["dd"]) && ($section["dd"] == "true") && !empty($section["enabled"]) && !($section["enabled"] == "false") && ($section["enabled"] == "true") && $section['name'] == "Settings") {
@@ -221,11 +221,11 @@ function menuItems()
         <ul class=\"drop-nav\">\n" . $dropdownmenu .
             "</ul></li></ul>\n\n\n<ul class=\"cd-tabs-navigation\"><nav>" .
             $standardmenu .
-            "<li><a id=\"reload\" title=\"Double click your app in the menu, or press this button to refresh the current app.\"><span class=\"fa fa-refresh fa-lg\"></span></a></li></ul></nav>";
+            "<li class='cd-tab'><a id=\"reload\" title=\"Double click your app in the menu, or press this button to refresh the current app.\"><span class=\"fa fa-refresh fa-lg\"></span></a></li></ul></nav>";
     } else {
         $item = "<nav><ul class=\"cd-tabs-navigation\">" .
             $standardmenu .
-            "<li><a id=\"reload\" title=\"Double click your app in the menu, or press this button to refresh the current app.\"><span class=\"fa fa-refresh fa-lg\"></span></a></li></ul></nav>";
+            "<li class='cd-tab'><a id=\"reload\" title=\"Double click your app in the menu, or press this button to refresh the current app.\"><span class=\"fa fa-refresh fa-lg\"></span></a></li></ul></nav>";
     }
     return $item;
 }


### PR DESCRIPTION
Hi,

I had a problem on my setup because I had too many items and when they were displayed in the mobile menu it didn't scroll. This means I couldn't access the items at the bottom of the list. To fix this I've added some css that only runs on the small screen sizes. I also added some css to set it's height to 80% of the screen size.

In addition I added some javascript to undo the change to the mobile menu. So you can go back to desktop from a small screen. This is all based on screen size, not user agent. To do this I added a cd-tab class to the drop-nav menu items.