### PR TITLE
Support for relative urls with custom ports

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -631,3 +631,19 @@ function setupMobileTicker() {
 		});
 		
 }
+
+// Parses passed url and looks for the form 'https://:34343/something'. If after double slash after protocol there is no host present, a local host is assumed and is placed before port part.
+// The url from the example will be transformed into 'https://somehost:34343/something', where somehost is the host at which the muximux was accessed.
+function parseRelativeUrlWithPortIfPresent(url) {
+    var parts = /^(http|https|ftp):\/\/:(\d+)(.*)$/.exec(url),
+        fullUrl;
+    if(parts) {
+        var protocol = parts[1],
+            port = parts[2],
+            relativePath = parts[3];
+        fullUrl = protocol + '://' + window.location.hostname + ':' + port + relativePath;
+    } else {
+        fullUrl = url;
+    }
+    return fullUrl; 
+}

--- a/js/functions.js
+++ b/js/functions.js
@@ -634,14 +634,16 @@ function setupMobileTicker() {
 
 // Parses passed url and looks for the form 'https://:34343/something'. If after double slash after protocol there is no host present, a local host is assumed and is placed before port part.
 // The url from the example will be transformed into 'https://somehost:34343/something', where somehost is the host at which the muximux was accessed.
-function parseRelativeUrlWithPortIfPresent(url) {
-    var parts = /^(http|https|ftp):\/\/:(\d+)(.*)$/.exec(url),
+// User is able also to add credentials to the custom port form i.e. 'ftp://login:password@:2525/path' and it will be transformed into 'ftp://login:password@somehost:2525/path'.
+var parseRelativeUrlWithPortIfPresent = function(url) {
+    var parts = /^([a-z][a-z0-9+\-.]*):\/\/(.*?:.*?@)?:(\d+)(.*)$/.exec(url),
         fullUrl;
     if(parts) {
         var protocol = parts[1],
-            port = parts[2],
-            relativePath = parts[3];
-        fullUrl = protocol + '://' + window.location.hostname + ':' + port + relativePath;
+            credentials = parts[2] ? parts[2] : '',
+            port = parts[3],
+            relativePath = parts[4];
+        fullUrl = protocol + '://' + credentials + window.location.hostname + ':' + port + relativePath;
     } else {
         fullUrl = url;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -100,7 +100,7 @@ jQuery(document).ready(function($) {
                     selectedContent.children('iframe').attr('src', selectedContent.children('iframe').attr('src'));
                 });
                 var sifsrc = selectedContent.children('iframe').attr('src');
-                var srcUrl = selectedContent.children('iframe').data('src');
+                var srcUrl = parseRelativeUrlWithPortIfPresent(selectedContent.children('iframe').data('src'));
                 if (sifsrc === undefined || sifsrc === "") {
                     selectedContent.children('iframe').attr('src', srcUrl);
                 }


### PR DESCRIPTION
## Intro
Instead of using `http://192.168.1.10:1111/foo` you can enter `http://:1111/foo` and Muximux will load page from the current host with the path and port specified appropiately. User is also able to specify login and password e.g. `ftp://user:password@:1211/foo` will be evaluated into `ftp://user:password@192.168.1.10:1211/foo`.

## Real world use case
Let's consider the following scenario: Apache+PHP exposes Muximux on both interfaces: 192.168.1.10 and 10.0.1.10. The services which will be available through Muximux are also exposed on both interfaces. Using current version of Muximux, one would have to have two Muximux instances with separate configurations for each of interfaces. This patch allows to have Muximux available on all interfaces with shared configuration, and services defined with relative paths and ports.