### PR TITLE
Deprecated each() function in php7.2

### DIFF
--- a/combineify.php
+++ b/combineify.php
@@ -22,7 +22,7 @@
 
     // Determine last modification date of the files
     $lastmodified = 0;
-    foreach ($lements as $key => $element) {
+    foreach ($elements as $key => $element) {
         $path = realpath($element);
 
         if (($type == 'javascript' && substr($path, -3) != '.js') ||

--- a/combineify.php
+++ b/combineify.php
@@ -22,7 +22,7 @@
 
     // Determine last modification date of the files
     $lastmodified = 0;
-    while (list(,$element) = each($elements)) {
+    foreach ($lements as $key => $element) {
         $path = realpath($element);
 
         if (($type == 'javascript' && substr($path, -3) != '.js') ||
@@ -103,7 +103,7 @@
         if ($type =='javascript') {
             $minifier = new Minify\JS();
         }
-        while (list(,$element) = each($elements)) {
+        foreach ($elements as $key => $element) {
             $path = realpath($element);
             $minifier->add($path);
         }


### PR DESCRIPTION
Ran into some problems with front-page rendering after upgrading to PHP 7.2.  This patch addresses the problems for me.