### PR TITLE
fixed disappearing menu with empty content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,7 +25,6 @@ body {
 	font-family: "PT Sans", sans-serif;
 	margin: 0px;
 	padding: 0px;
-	overflow: hidden;
 }
 
 a {


### PR DESCRIPTION
the drop down menu gets hidden when there's no active content when no default is selected. you see a few pixels of it but that's it. a small css tweak resolves this annoying bug.

tested on:
win-chrome
mac-safari
android-chrome
android-firefox
ios-safari.  