### PR TITLE
fix two safari UI issues

### DIFF
--- a/css/font-muximux.css
+++ b/css/font-muximux.css
@@ -7873,3 +7873,7 @@
   content: "\f2e0";
 }
 
+.muximux-navbtn-icon {
+  display: block;
+  line-height: 1;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -88,24 +88,24 @@ p {
 }
 
 @media only screen and (max-width: 767px) {
-	
+
 	.form-control {
 		text-align: center;
 	}
-	
+
 	.caret, .sp-dd {
 		display: none;
 	}
-	
+
 	select {
 		text-align: center;
 		text-align-last: center;
 	}
-	
+
 	.sp-preview {
 		width: 99%!important;
 	}
-	
+
 }
 
 @media only screen and (min-width: 768px) {
@@ -137,7 +137,7 @@ p {
 		height: 75%;
 		overflow: auto;
 		border-radius: 10px;
-    
+
 }
 @media only screen and (min-width: 2560px) {
 	.hidden-xl-up {
@@ -205,7 +205,8 @@ div.entryTitle a {
 	.cd-tabs-navigation a:not(#reload) {
 		height: 40px;
 		line-height: 40px;
-		width: 105%;
+		width: 100%;
+    white-space: nowrap;
 		text-align: center;
 		font-size: 1.6rem;
 		padding: 0 2em 0 2em;
@@ -536,19 +537,19 @@ input[type='button'] {
 		padding: 0px;
 		position: absolute;
 	}
-	
+
 	.feedWrapper {
 		padding: 0px;
 		height: 40px;
-		
+
 	}
-	
+
 	.TickerNews {
 		width: 100%;
 		height: 50px;
 		line-height: 48px;
 	}
-	
+
 	.ti_wrapper {
 		width: 100%;
 		float: left;
@@ -556,35 +557,35 @@ input[type='button'] {
 		position: relative;
 		overflow: hidden;
 	}
-	
+
 	.ti_slide{
 		width: 100%;
 		position: relative;
 		left: 0;
 		top: 0;
 	}
-	
+
 	.ti_content{
 		width: 8000px;
 		position: relative;
 		float:left;
 		height: 40px;
-		
+
 	}
-		
+
 	.splashHeader .logo {
 		display: none;
 	}
-	
+
 	#splashContainer {
 		padding: 42px 10px 30px 10px;
 	}
-	
+
 	.TickerNews {
 		width: 70%;
-		
+
 	}
-	
+
 	#splashNav {
 		position: relative;
 		display: inline-block;
@@ -593,7 +594,7 @@ input[type='button'] {
 		bottom: 40px;
 		float: right;
 	}
-		
+
 	.btn-lg {
 		padding: 6px 12px !important;
 	}

--- a/css/style.css
+++ b/css/style.css
@@ -205,7 +205,7 @@ div.entryTitle a {
 	.cd-tabs-navigation a:not(#reload) {
 		height: 40px;
 		line-height: 40px;
-		width: 100%;
+		width: 105%;
 		text-align: center;
 		font-size: 1.6rem;
 		padding: 0 2em 0 2em;

--- a/muximux.php
+++ b/muximux.php
@@ -574,23 +574,23 @@ function menuItems() {
 			<ul class='main-nav'>
                 <li class='navbtn ".(($mobileoverride == "true") ? '' : 'hidden')."'>
                     <a id='override' title='Click this button to disable mobile scaling on tablets or other large-resolution devices.'>
-                        <span class='fa muximux-mobile fa-lg'></span>
+                        <span class='fa muximux-mobile muximux-navbtn-icon fa-lg'></span>
                     </a>
                 </li>
                 <li class='navbtn ".(($splashScreen == "true") ? '' : 'hidden')."'>
 			<a id='showSplash' data-toggle='modal' data-target='#splashModal' data-title='Show Splash'>
-                	<span class='fa muximux-home4 fa-lg'></span>
+                	<span class='fa muximux-home4 muximux-navbtn-icon fa-lg'></span>
                     </a>
                 </li>
 
                 <li class='navbtn ".(($authentication == "true") ? '' : 'hidden')."'>
                     <a id='logout' title='Click this button to log out of Muximux.'>
-                        <span class='fa muximux-sign-out fa-lg'></span>
+                        <span class='fa muximux-sign-out muximux-navbtn-icon fa-lg'></span>
                     </a>
                 </li>
 				<li class='navbtn'>
                     <a id='reload' title='Double click your app in the menu, or press this button to refresh the current app.'>
-                        <span class='fa muximux-refresh fa-lg'></span>
+                        <span class='fa muximux-refresh muximux-navbtn-icon fa-lg'></span>
                     </a>
                 </li>
 
@@ -606,7 +606,7 @@ function menuItems() {
             $moButton ."
                 <li class='dd navbtn'>
                     <a id='hamburger'>
-                        <span class='fa fa-bars fa-lg'></span>
+                        <span class='fa fa-bars muximux-navbtn-icon fa-lg'></span>
                     </a>
                     <ul class='drop-nav'>" .
                                 $dropdownmenu ."


### PR DESCRIPTION
this fixes two UI issues under safari.  it fixes the height of the menubar and it fixes the menubar item text being cut off.
#125 
#151 
<img width="971" alt="Screen Shot 2021-01-24 at 12 59 12 PM" src="https://user-images.githubusercontent.com/8324605/105639195-d9375000-5e44-11eb-8206-4aece623177a.png">

fixing the menubar height appears to have no issues on other browsers.
<img width="726" alt="Capture" src="https://user-images.githubusercontent.com/8324605/105639297-61b5f080-5e45-11eb-9df0-36139dacaa8b.PNG">

however the text cutoff is more of a workaround, it causes a little bit of overlap between buttons on _**mouseover**_, but I think it's an improvment compared to the current state under safari.  
<img width="971" alt="Screen Shot 2021-01-24 at 1 00 13 PM" src="https://user-images.githubusercontent.com/8324605/105639187-cae93400-5e44-11eb-973f-95f70468d18f.png">

