### PR TITLE
Remove port from {self}

### DIFF
--- a/muximux.php
+++ b/muximux.php
@@ -117,7 +117,7 @@ function write_ini()
 // set $_SERVER['HTTP_HOST'] when {self}
 function selfURL_managment ($url) {
 	if  (strpos($url,'{self}')  !== FALSE) {
-		$url = str_replace('{self}',$_SERVER['HTTP_HOST'],$url);
+		$url = str_replace('{self}',strtok($_SERVER['HTTP_HOST'],':'),$url);
 	}
 	return $url;
 }


### PR DESCRIPTION
If Muximux is not running on port 80, when using {self}, it would be replaced with a url that contains the Muximux port. This breaks all links to other services which also require their own port. For example, Emby running on its default port of 8096.

E.G. Muximux set to run on port 8080. http://{self}:8096/ would become http//some_url:8080:8096/ and fail to load as it is not a valid URL.