### PR TITLE
Start navigation collapsed on mount when auto_hide is enabled

### DIFF
--- a/web/src/components/Navigation.svelte
+++ b/web/src/components/Navigation.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import type { App, Config, Group } from '$lib/types';
   import AppIcon from './AppIcon.svelte';
   import HealthIndicator from './HealthIndicator.svelte';
@@ -234,7 +234,10 @@
   let maxWidth = 400;
 
   // Auto-hide state
-  let isHidden = $state(false);
+  // Start collapsed when auto_hide is enabled so the nav doesn't sit open on
+  // first paint until the user happens to mouse over and then leave it.
+  // untrack: this is an initial-value snapshot, not a reactive subscription.
+  let isHidden = $state(untrack(() => config.navigation.auto_hide === true));
   let hideTimeout: ReturnType<typeof setTimeout> | null = null;
   // Delay overflow:visible on top/bottom bars until height transition (300ms) completes
   let barOverflowVisible = $state(false);
@@ -401,6 +404,16 @@
     if (leftScrollEl) scrollObserver.observe(leftScrollEl);
     if (rightScrollEl) scrollObserver.observe(rightScrollEl);
     if (floatScrollEl) scrollObserver.observe(floatScrollEl);
+
+    // If the cursor is already over the nav at mount time, mouseenter won't
+    // fire — reveal the nav so the user isn't stuck staring at a collapsed
+    // bar they're already hovering. Sidebars use <aside>, top/bottom bars
+    // use <nav>, and the floating layout uses a <nav> too.
+    if (config.navigation.auto_hide) {
+      requestAnimationFrame(() => {
+        if (document.querySelector('nav:hover, aside:hover')) handleNavEnter();
+      });
+    }
 
     return () => {
       window.removeEventListener('resize', debouncedResize);

--- a/web/src/components/Navigation.test.ts
+++ b/web/src/components/Navigation.test.ts
@@ -1289,11 +1289,35 @@ describe('Navigation', () => {
           config: makeConfig({ navigation: { position: 'top', auto_hide: true } }),
         },
       });
-      const panel = container.querySelector('.top-nav-panel');
-      // isHidden starts as false, but isCollapsedTop = isHidden && auto_hide
-      // After mount, isHidden defaults to false, so panel height should be 56px
-      // (the nav height is 6px as placeholder but the panel overlays at 56px initially)
+      const panel = container.querySelector('.top-nav-panel') as HTMLElement;
+      // isHidden initialises to true when auto_hide=true, so the panel renders
+      // in its collapsed state on mount (height matches collapsedBarHeight).
       expect(panel).toBeTruthy();
+      expect(panel.style.height).toBe('6px');
+    });
+
+    it('top nav inner panel starts at full height when auto_hide=false', () => {
+      const { container } = render(Navigation, {
+        props: {
+          apps: ungroupedApps,
+          currentApp: null,
+          config: makeConfig({ navigation: { position: 'top', auto_hide: false } }),
+        },
+      });
+      const panel = container.querySelector('.top-nav-panel') as HTMLElement;
+      expect(panel.style.height).toBe('56px');
+    });
+
+    it('bottom nav inner panel starts at collapsed height when auto_hide=true', () => {
+      const { container } = render(Navigation, {
+        props: {
+          apps: ungroupedApps,
+          currentApp: null,
+          config: makeConfig({ navigation: { position: 'bottom', auto_hide: true } }),
+        },
+      });
+      const panel = container.querySelector('.bottom-nav-panel') as HTMLElement;
+      expect(panel.style.height).toBe('6px');
     });
 
     it('bottom nav sets collapsed bar height when auto_hide=true', () => {


### PR DESCRIPTION
## Summary

When \`navigation.auto_hide\` is enabled, the nav rendered in its **expanded** state on first paint and only collapsed *after* a mouse-enter+leave cycle. If the cursor never touched the nav (a fresh page load on a desktop where the cursor lives in the middle of the screen), the nav stayed open indefinitely — defeating the point of auto-hide.

This change makes the nav start collapsed when \`auto_hide\` is on, and reveals it on mount only if the cursor is already over the nav region (since \`mouseenter\` doesn't fire in that case).

## The change

\`web/src/components/Navigation.svelte\`:

- \`isHidden\` initialiser now reflects \`config.navigation.auto_hide\` instead of being hardcoded to \`false\`.
- In \`onMount\`, after the nav has rendered, check \`document.querySelector('nav:hover, aside:hover')\` (sidebars use \`<aside>\`, top/bottom/floating use \`<nav>\`) — if the cursor is already inside, call \`handleNavEnter()\` to reveal it.

### Why \`untrack\`?

The \`$state(...)\` initialiser reads \`config.navigation.auto_hide\` once. Svelte 5 (correctly) warns that this captures the initial value only and won't re-react to later prop changes — \`state_referenced_locally\`. That one-time snapshot is the **intended** behavior here: toggling auto-hide mid-session via Settings shouldn't yank the nav closed underneath the user. Wrapping in \`untrack(() => …)\` documents that intent and silences the warning, instead of using a workaround like a \`$derived\` that would over-eagerly recompute.

## Tests

\`web/src/components/Navigation.test.ts\`:

- Tightened the existing top-bar auto-hide test to assert the panel renders at the collapsed height (6px) on mount, not just that it exists.
- Added a sibling test for \`auto_hide=false\` (56px) and one for the bottom bar with \`auto_hide=true\` (6px).
- Verified manually in the browser: on a fresh load with auto-hide enabled, the left sidebar renders as a 48px strip instead of the full 220px. Hover expands it, leave collapses it after the configured delay.

Coverage stays above the 85% threshold (Statements 85.98%).

## Test plan

- [x] \`cd web && npm run check && npm run lint && npm run test:coverage\` — all green.
- [x] Manual: enable Auto-hide in Settings → Navigation, reload, confirm the nav is collapsed on first paint.
- [x] Manual: confirm hovering still expands and leaving still collapses (no behavior change to the existing reveal flow).
- [x] Manual: with auto_hide off, confirm nav still renders fully expanded as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation auto-hide behavior to properly detect when users hover over the navigation during page load, ensuring the navigation expands correctly instead of remaining collapsed.

* **Tests**
  * Updated navigation tests to verify panels render at the correct initial heights based on auto-hide configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Muximux/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->