### PR TITLE
fix(docker): arm64 image ships an amd64 binary (global ARG default shadows TARGETARCH)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,11 +139,14 @@ jobs:
             cid="$(docker create --platform="linux/${arch}" "${image}" /app/muximux)"
             docker cp "${cid}:/app/muximux" "/tmp/muximux-${arch}"
             docker rm "${cid}" >/dev/null
-            machine="$(readelf -h "/tmp/muximux-${arch}" | sed -n 's/.*Machine:[[:space:]]*//p')"
-            echo "linux/${arch} image -> ${machine}"
-            case "${arch}" in
-              amd64) echo "${machine}" | grep -qi 'X86-64'  || { echo "::error::linux/amd64 image does not contain an x86-64 binary (${machine})"; rc=1; } ;;
-              arm64) echo "${machine}" | grep -qi 'AArch64' || { echo "::error::linux/arm64 image does not contain an AArch64 binary (${machine})"; rc=1; } ;;
+            # ELF e_machine is a little-endian 2-byte field at offset 18:
+            # 3e00 = x86-64, b700 = AArch64. Read with od (coreutils) so this
+            # check has no dependency on binutils/readelf being installed.
+            machine="$(od -An -tx1 -j18 -N2 "/tmp/muximux-${arch}" | tr -d ' ')"
+            echo "linux/${arch} image -> e_machine=${machine}"
+            case "${arch}:${machine}" in
+              amd64:3e00|arm64:b700) : ;;
+              *) echo "::error::linux/${arch} image has a wrong-arch binary (e_machine=${machine})"; rc=1 ;;
             esac
           done
           exit "${rc}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
@@ -123,6 +124,29 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Guards against the cross-compile regression where every platform's
+      # image shipped the same amd64 binary (an amd64 binary inside the arm64
+      # image, which then crashes under QEMU on real arm64 hosts). Pull each
+      # platform variant by digest and assert the embedded binary's ELF
+      # machine type matches the image platform.
+      - name: Verify each platform ships a matching-arch binary
+        run: |
+          set -euo pipefail
+          image="${REGISTRY}/${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+          rc=0
+          for arch in amd64 arm64; do
+            cid="$(docker create --platform="linux/${arch}" "${image}" /app/muximux)"
+            docker cp "${cid}:/app/muximux" "/tmp/muximux-${arch}"
+            docker rm "${cid}" >/dev/null
+            machine="$(readelf -h "/tmp/muximux-${arch}" | sed -n 's/.*Machine:[[:space:]]*//p')"
+            echo "linux/${arch} image -> ${machine}"
+            case "${arch}" in
+              amd64) echo "${machine}" | grep -qi 'X86-64'  || { echo "::error::linux/amd64 image does not contain an x86-64 binary (${machine})"; rc=1; } ;;
+              arm64) echo "${machine}" | grep -qi 'AArch64' || { echo "::error::linux/arm64 image does not contain an AArch64 binary (${machine})"; rc=1; } ;;
+            esac
+          done
+          exit "${rc}"
 
   create-release:
     name: Create Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-# Automatic platform args. buildx sets these per target; the
-# defaults keep a plain `docker build` (no buildx, no --platform)
-# working on the host that runs it.
-ARG BUILDPLATFORM=linux/amd64
-ARG TARGETPLATFORM=linux/amd64
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# Predefined platform args, populated by BuildKit: per --platform target under
+# buildx, or from the host platform for a plain `docker build`. Declared WITHOUT
+# values on purpose — an ARG default shadows BuildKit's per-target value and
+# cross-compiles every target to that default, which is how an amd64 binary
+# ended up inside the arm64 image.
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 # Build stage - Frontend
 #
@@ -48,14 +50,15 @@ COPY internal/ ./internal/
 # Copy frontend build
 COPY --from=frontend /app/internal/server/dist ./internal/server/dist
 
-# Build binary. TARGETOS / TARGETARCH are populated automatically
-# by buildx for each entry in --platform; defaults keep a plain
-# `docker build` (no buildx, no --platform) working on amd64.
+# Build binary. TARGETOS / TARGETARCH come from BuildKit — the --platform target
+# under buildx, or the host platform for a plain `docker build`. No ARG default,
+# so the per-target value isn't shadowed; for a plain build that means a
+# host-native binary.
 ARG VERSION=dev
 ARG COMMIT=none
 ARG BUILD_DATE=unknown
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" go build \
     -tags embed_web \
     -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \


### PR DESCRIPTION
## Summary

The published **`linux/arm64` image contains an `amd64` binary**. On real arm64 hosts it runs under QEMU emulation and crashes on startup with:

```
runtime: pointer ... to unallocated span ...
fatal error: found bad pointer in Go heap (incorrect use of unsafe or cgo?)
```

(This is a known Go-under-QEMU emulation failure — see [golang/go#77572](https://github.com/golang/go/issues/77572) — so an amd64 binary emulated on an arm64 host is unreliable even when it doesn't crash immediately.)

This affects **v3.1.0 and v3.1.1** (regression introduced in [`8630dc9f`](https://github.com/mescon/Muximux/commit/8630dc9f12782555305ff78b6337766ee25e2cbd), "Dockerfile: cross-compile instead of emulating arm64 under QEMU"). v3.0.32 and earlier are unaffected.

## Root cause

`TARGETOS` / `TARGETARCH` are *predefined* build args that BuildKit fills in per `--platform` target. The Dockerfile declares them **in the global scope with defaults**:

```dockerfile
ARG TARGETOS=linux
ARG TARGETARCH=amd64
```

A global default **shadows BuildKit's automatic per-target value**, so the redeclaration inside the build stage inherits the literal `amd64` and the cross-compile runs `GOARCH=amd64` for *every* target. The result: both platform images receive the byte-identical amd64 binary.

Evidence from the published v3.1.1 manifest — both platforms, same binary:

```
linux/amd64 -> e_machine 0x3e (x86-64)  sha256 9be966ac…
linux/arm64 -> e_machine 0x3e (x86-64)  sha256 9be966ac…   ← should be 0xb7 / AArch64
```

The final `FROM alpine` stage *is* built per-target, so `docker image inspect` still reports `Architecture: arm64` while the embedded binary is amd64 — which is what makes this easy to miss.

## Fix

Keep the `ARG` declarations but **drop their default values**. A default on a predefined platform arg (`ARG TARGETARCH=amd64`) — global scope or build stage — shadows BuildKit's automatic per-target value; a valueless `ARG TARGETARCH` lets the real per-target value flow through. This matches [Docker's documented cross-compilation pattern](https://docs.docker.com/build/building/multi-platform/#cross-compilation).

The maintainer's intent — a plain `docker build` should "just work on the host" — is preserved without the defaults. A plain `docker build` runs under BuildKit, which fills `TARGETOS`/`TARGETARCH` from the **host platform**, so the build produces a host-native binary. (This is actually closer to the original intent than the old `=amd64` default, which forced amd64 even on a non-amd64 host.)

Verified on an arm64 host:

| Build | Result |
|---|---|
| `buildx --platform linux/arm64` | arm64 ✅ |
| `buildx --platform linux/amd64` | amd64 ✅ |
| plain `docker build` (no `--platform`) | host-native arm64 ✅ |

## Regression guard (CI)

This PR also adds a step to the `build-docker` job that, after build-push, pulls each platform variant by digest and asserts the embedded binary's ELF machine type matches the image platform (`amd64 -> X86-64`, `arm64 -> AArch64`). If the wrong-arch binary ever ships again, the release fails loudly instead of silently.

## How this was tested

Isolating the exact variable (trivial Go program built through the same ARG structure, on an arm64 host):

| Pattern | `--platform` target | Binary produced |
|---|---|---|
| **before** (global `ARG` default) | linux/**arm64** | **amd64** ❌ |
| before | linux/amd64 | amd64 ✅ (only because the shadowed default *was* amd64) |
| **after** (this PR) | linux/**arm64** | **arm64** ✅ |
| after | linux/amd64 | amd64 ✅ |

Reproduce / verify against the real image:

```bash
for arch in amd64 arm64; do
  cid=$(docker create --platform=linux/$arch ghcr.io/mescon/muximux:latest /app/muximux)
  docker cp "$cid:/app/muximux" /tmp/m-$arch; docker rm "$cid" >/dev/null
  printf '%s -> ' "$arch"; readelf -h /tmp/m-$arch | sed -n 's/.*Machine:[[:space:]]*//p'
done
# expected after fix: amd64 -> X86-64, arm64 -> AArch64
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image builds with automated verification to ensure correct binaries for each supported platform.
  * Improved multi-architecture build configuration for better cross-platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Muximux/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->