### PR TITLE
fix(proxy): stop stripping integrity/crossorigin inside JS string literals (#371)

### DIFF
--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -207,7 +207,7 @@ func (r *contentRewriter) rewrite(content []byte) []byte {
 // third-party servers (e.g. plex.tv). ES module imports are an exception
 // because the browser's module loader bypasses fetch/XHR interception.
 func (r *contentRewriter) rewriteScript(content []byte) []byte {
-	content = r.stripIntegrity(content)
+	content = r.stripDynamicSRI(content)
 	content = r.rewriteAbsoluteURLs(content)
 	content = r.rewriteTargetPaths(content)
 	content = r.rewriteURLBase(content)
@@ -215,10 +215,23 @@ func (r *contentRewriter) rewriteScript(content []byte) []byte {
 	return content
 }
 
-// stripIntegrity removes integrity and crossorigin attributes since we modify
-// content (breaks SRI hashes), and neutralises dynamic SRI in webpack loaders.
+// stripIntegrity removes HTML integrity/crossorigin attributes (we modify
+// content, which breaks SRI hashes) and neutralises dynamic SRI in webpack
+// loaders. HTML only -- the attribute pattern is unanchored and false-matches
+// these words inside minified JS string literals, so the JS path uses
+// stripDynamicSRI instead.
 func (r *contentRewriter) stripIntegrity(result []byte) []byte {
 	result = integrityPattern.ReplaceAll(result, nil)
+	return r.stripDynamicSRI(result)
+}
+
+// stripDynamicSRI neutralises webpack's runtime SRI (the dynamic
+// `x.integrity = y.sriHashes[z]` assignment and the `sriHashes` table) without
+// touching HTML integrity/crossorigin attributes. The attribute form is an
+// HTML construct; in JavaScript those words only appear inside string literals
+// (e.g. Bazarr builds the CSS selector `'[crossorigin="' + a + '"]'`), where
+// stripping them corrupts the script. Safe for JS and JSON. (#371)
+func (r *contentRewriter) stripDynamicSRI(result []byte) []byte {
 	result = dynamicSriPattern.ReplaceAll(result, nil)
 	result = sriHashesPattern.ReplaceAll(result, r.sriHashRepl)
 	return result

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -2694,6 +2694,48 @@ func TestStripIntegrity(t *testing.T) {
 	}
 }
 
+// TestRewriteScriptPreservesJSStringLiterals guards against #371: the HTML
+// integrity/crossorigin attribute stripper false-matched those words inside
+// minified JS string literals and corrupted the script. The JS path must
+// neutralise only webpack's dynamic SRI, never the attribute form.
+func TestRewriteScriptPreservesJSStringLiterals(t *testing.T) {
+	rewriter := newContentRewriter("/proxy/bazarr", "", "")
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			// The exact Bazarr construct that broke (#371): builds the CSS
+			// selector [crossorigin="<a>"]. Must pass through untouched.
+			name:     "crossorigin in JS string literal is preserved",
+			input:    `o+='[crossorigin="'+a+'"]'`,
+			expected: `o+='[crossorigin="'+a+'"]'`,
+		},
+		{
+			name:     "integrity word in JS string literal is preserved",
+			input:    `t='<link integrity="'+h+'">'`,
+			expected: `t='<link integrity="'+h+'">'`,
+		},
+		{
+			// Webpack dynamic SRI must still be neutralised in JS.
+			name:     "webpack dynamic SRI still neutralised",
+			input:    `b.integrity=b.sriHashes[c],b.sriHashes={x:"y"}`,
+			expected: `b.sriHashes={}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := string(rewriter.rewriteScript([]byte(tt.input)))
+			if result != tt.expected {
+				t.Errorf("rewriteScript() =\n  got:  %q\n  want: %q", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestStripMetaCSP(t *testing.T) {
 	rewriter := newContentRewriter("/proxy/app", "", "")
 


### PR DESCRIPTION
## Summary

Fixes #371 -- Bazarr (and any app whose JavaScript contains the literal text `integrity="..."` or `crossorigin="..."`) renders blank when accessed through the built-in proxy with `proxy: true`.

## Root cause

The reverse proxy's HTML `integrity` / `crossorigin` attribute stripper (`integrityPattern`) was applied to JavaScript responses as well as HTML. Those words are an HTML-attribute construct, but in minified JS they also appear inside string literals. Bazarr builds a CSS selector:

```js
o+='[crossorigin="'+a+'"]'
```

The unanchored pattern matched `crossorigin="'` inside that string literal and deleted it, leaving `o+='[+a+'"]'`. That breaks the string and unbalances the surrounding parenthesised expression, so the browser cannot parse the module and the app renders blank.

## Verification

Reproduced against Bazarr's real bundle (`index-BxYEpruO.js`, the exact file from the report):

- The corruption lands at line 10, matching the reported error location `index-BxYEpruO.js:10` precisely.
- The corrupted bundle fails an ES-module parse (`Invalid or unexpected token` in V8, reported as `missing ) in parenthetical` in SpiderMonkey/Firefox). It is only caught in module mode, which is why a plain script-mode check did not surface it.
- With this change the bundle parses cleanly and the `crossorigin` selector is preserved byte-for-byte.

## Fix

The JS and JSON path now neutralises only webpack's dynamic SRI (the `x.integrity = y.sriHashes[z]` assignment and the `sriHashes` table) via a new `stripDynamicSRI` helper. The HTML attribute stripper (`integrityPattern`) is no longer run on script content. HTML rewriting is unchanged.

Adds a regression test (`TestRewriteScriptPreservesJSStringLiterals`) with the exact Bazarr construct.

## Test plan

- [x] `go test ./internal/handlers/...` passes (new regression test included)
- [x] Bazarr's real bundle parses as an ES module after rewriting
- [ ] Reporter confirmation that Bazarr loads through the proxy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response rewriting so JavaScript and JSON content no longer accidentally removes text that merely looks like SRI-related attributes inside string literals.
  * HTML responses still strip integrity-related attributes, and dynamic SRI patterns are now also neutralized there for more consistent handling.
  * Added coverage to ensure minified scripts keep normal string content intact while still disabling dynamic SRI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->