### PR TITLE
feat(discovery): opt-in automatic import of Docker-labeled containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Muximux are documented in this file.
 
+## [Unreleased]
+
+### Added
+- Automatic import of `muximux.*`-labeled Docker containers, opt-in via
+  `discovery.docker.auto_import` (or `MUXIMUX_DISCOVERY_AUTO_IMPORT`):
+  `off` (default), `add`, `update`, or `sync` (full GitOps mirror). Disabled
+  by default; enabling it imports every labeled container without a manual
+  review step. Hand-editing an auto-imported app detaches it so local changes
+  win.
+
 ## [3.1.4] - 2026-06-29
 
 A reverse-proxy fix plus routine dependency maintenance. Upgrading is a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,13 @@ services:
       #
       # Override the config file path (default: derived from data dir)
       # - MUXIMUX_CONFIG=/app/data/config.yaml
+      #
+      # Automatically import muximux.*-labeled containers (3.2.0+).
+      # off (default) | add | update | sync. With sync, Muximux mirrors
+      # labeled containers exactly (adds, updates, and removes apps).
+      # Enabling this imports every labeled container with no review step,
+      # including gateway subdomains. See docs/wiki/docker-discovery.md.
+      # - MUXIMUX_DISCOVERY_AUTO_IMPORT=sync
 
       # ── Config File Variable Expansion ──────────────────────────
       # These are available for ${VAR} expansion inside config.yaml.

--- a/docs/wiki/docker-discovery.md
+++ b/docs/wiki/docker-discovery.md
@@ -298,9 +298,11 @@ MUXIMUX_DISCOVERY_AUTO_IMPORT=sync
 
 A container with `muximux.app.enabled=false` is excluded from auto-import (and from the Discover modal). Use it to keep a labeled container off the dashboard without stripping its labels.
 
-### Edit-wins (hand-editing detaches)
+### Edit-wins (URL edits detach)
 
-Auto-import never clobbers your manual changes. If you hand-edit an auto-imported app -- in Settings, through the API, or in `config.yaml` directly -- Muximux notices the divergence and **detaches** that app from auto-management. From then on it is a normal manual entry: `update`/`sync` will not re-sync it from labels, and `sync` will not remove it. Your edit wins. This is the same edit-lock / auto-detach mechanism described below for tracked URLs.
+Auto-import never silently clobbers a URL you took manual control of. **Changing an auto-imported app's URL** -- in Settings, through the API, or in `config.yaml` directly -- or **removing the container's `muximux.*` labels** detaches that app from auto-management. From then on it is a normal manual entry: `update`/`sync` will not re-sync it from labels, and `sync` will not remove it. This is the same edit-lock / auto-detach mechanism described below for tracked URLs.
+
+Other managed-field edits (name, icon, group, and similar) do **not** detach. Under `update`/`sync` they are re-synced from the labels on the next tick, so the labels remain the source of truth; under `add` they stick, because `add` never re-syncs an already-imported app.
 
 ### Known limitation -- gateway-only labels and `update`/`sync`
 

--- a/docs/wiki/docker-discovery.md
+++ b/docs/wiki/docker-discovery.md
@@ -260,6 +260,56 @@ Unknown `muximux.*` labels are surfaced in the Discover modal's per-row notes so
 
 ---
 
+## Automatic Import
+
+Everything above is the **manual** path: labels become high-confidence pre-fills, and you click **Import** to commit them. Automatic import removes that review step. When enabled, Muximux imports every `muximux.*`-labeled container on the daemon by itself -- no modal, no click -- and keeps the imported apps in step with the labels over time.
+
+> **Security -- read before enabling.** Auto-import is **off by default** and only the host operator (who controls `config.yaml` or the environment) can turn it on. Once on, **any container on the shared Docker socket can write itself into your config with no review step** -- including a `muximux.app.gateway.domain` label that publishes a **public HTTPS subdomain with an auto-issued ACME certificate**. Treat enabling this as trusting every label on every container the daemon can see. If you don't control all of those containers, leave it `off` and import by hand.
+
+### Modes
+
+Set the mode with the `discovery.docker.auto_import` config key, or override it with the `MUXIMUX_DISCOVERY_AUTO_IMPORT` environment variable (the env var wins). Four values:
+
+| Mode | Adds new labeled containers | Re-syncs app fields when labels change | Removes the app when the container disappears |
+|---|---|---|---|
+| `off` (default) | no -- labels stay suggestions you import by hand | no | no |
+| `add` | yes, once | no -- imported, then left alone forever | no |
+| `update` | yes | yes | no |
+| `sync` | yes | yes | yes -- full GitOps mirror |
+
+- **`off`** -- today's behavior. Labeled containers are suggestions only; nothing is written until you click **Import**.
+- **`add`** -- a newly labeled container is imported one time, then never touched again. Good for bootstrapping.
+- **`update`** -- like `add`, plus Muximux re-syncs the app's fields from the labels whenever they change. Never removes anything.
+- **`sync`** -- like `update`, plus when a tracked container disappears from the daemon the auto-imported app (and its gateway site) is removed. The config becomes an exact mirror of the labeled containers.
+
+```yaml
+discovery:
+  docker:
+    enabled: true
+    auto_import: sync   # off (default) | add | update | sync
+```
+
+```bash
+# Environment override (takes precedence over config.yaml):
+MUXIMUX_DISCOVERY_AUTO_IMPORT=sync
+```
+
+### Opting a container out
+
+A container with `muximux.app.enabled=false` is excluded from auto-import (and from the Discover modal). Use it to keep a labeled container off the dashboard without stripping its labels.
+
+### Edit-wins (hand-editing detaches)
+
+Auto-import never clobbers your manual changes. If you hand-edit an auto-imported app -- in Settings, through the API, or in `config.yaml` directly -- Muximux notices the divergence and **detaches** that app from auto-management. From then on it is a normal manual entry: `update`/`sync` will not re-sync it from labels, and `sync` will not remove it. Your edit wins. This is the same edit-lock / auto-detach mechanism described below for tracked URLs.
+
+### Known limitation -- gateway-only labels and `update`/`sync`
+
+In `update` and `sync`, re-sync compares the **app** fields built from labels against the stored app. Gateway labels that change the app's URL -- `muximux.app.gateway.domain` and `muximux.gateway.tls` -- do change an app field, so edits to them **do** propagate on the next tick.
+
+Gateway-**only** labels that do not map to any app field -- `muximux.gateway.require_auth`, `muximux.gateway.min_role`, `muximux.gateway.streaming`, `muximux.gateway.strip_frame_blockers`, and `muximux.gateway.forwarded_headers` -- are **not** picked up by re-sync. Changing one of these labels on a running, already-imported container has no effect until either an app field also changes, or you remove and re-add the container (which re-imports it from scratch). So if you rely on, say, toggling `muximux.gateway.require_auth` via a label, know that auto-import will not apply that toggle on its own.
+
+---
+
 ## Routing Modes Explained
 
 When you check "Add to menu" in the import modal, a radio selector decides how the menu link works:

--- a/internal/config/autoimport_env.go
+++ b/internal/config/autoimport_env.go
@@ -1,0 +1,16 @@
+package config
+
+// EnvAutoImport is the direct override for discovery.docker.auto_import.
+const EnvAutoImport = "MUXIMUX_DISCOVERY_AUTO_IMPORT"
+
+// ApplyAutoImportEnv overrides the configured auto-import mode from the
+// environment when EnvAutoImport is set. The value is normalized (unknown
+// -> off). getenv is injected so tests need not touch the real environment.
+func ApplyAutoImportEnv(cfg *Config, getenv func(string) (string, bool)) {
+	if cfg == nil {
+		return
+	}
+	if v, ok := getenv(EnvAutoImport); ok {
+		cfg.Discovery.Docker.AutoImport = NormalizeAutoImport(AutoImportMode(v))
+	}
+}

--- a/internal/config/autoimport_env_test.go
+++ b/internal/config/autoimport_env_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestApplyAutoImportEnv(t *testing.T) {
+	cfg := &Config{}
+	cfg.Discovery.Docker.AutoImport = AutoImportOff
+
+	// env set: overrides yaml
+	ApplyAutoImportEnv(cfg, func(k string) (string, bool) {
+		if k == "MUXIMUX_DISCOVERY_AUTO_IMPORT" {
+			return "sync", true
+		}
+		return "", false
+	})
+	if cfg.Discovery.Docker.AutoImport != AutoImportSync {
+		t.Fatalf("env override failed: got %q", cfg.Discovery.Docker.AutoImport)
+	}
+
+	// env absent: yaml value preserved
+	cfg.Discovery.Docker.AutoImport = AutoImportAdd
+	ApplyAutoImportEnv(cfg, func(string) (string, bool) { return "", false })
+	if cfg.Discovery.Docker.AutoImport != AutoImportAdd {
+		t.Fatalf("absent env should preserve yaml: got %q", cfg.Discovery.Docker.AutoImport)
+	}
+
+	// env garbage: fails closed to off
+	ApplyAutoImportEnv(cfg, func(string) (string, bool) { return "nonsense", true })
+	if cfg.Discovery.Docker.AutoImport != AutoImportOff {
+		t.Fatalf("garbage env should fail closed: got %q", cfg.Discovery.Docker.AutoImport)
+	}
+
+	// nil cfg: guarded, must not panic
+	ApplyAutoImportEnv(nil, func(string) (string, bool) { return "sync", true })
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,9 @@ type DiscoveryDockerConfig struct {
 	HostIP          string             `yaml:"host_ip,omitempty" json:"host_ip,omitempty"`
 	NetworkFilter   string             `yaml:"network_filter,omitempty" json:"network_filter,omitempty"`
 	RefreshInterval string             `yaml:"refresh_interval" json:"refresh_interval"` // e.g. "60s"
+	// AutoImport controls automatic import of muximux.*-labeled
+	// containers. off (default) | add | update | sync. See AutoImportMode.
+	AutoImport AutoImportMode `yaml:"auto_import,omitempty" json:"auto_import,omitempty"`
 
 	// Container lifecycle controls (Splash actions). Two-layer opt-in:
 	// also requires the Docker socket to be mounted read-write at
@@ -122,6 +125,37 @@ const (
 	// in a Desktop / WSL container.
 	StrategyHostDockerInternal NetworkStrategy = "host_docker_internal"
 )
+
+// AutoImportMode controls whether labeled containers are imported into
+// config automatically, and how aggressively. Off by default.
+type AutoImportMode string
+
+const (
+	AutoImportOff    AutoImportMode = "off"    // suggestions only (manual import)
+	AutoImportAdd    AutoImportMode = "add"    // auto-add new; never update or remove
+	AutoImportUpdate AutoImportMode = "update" // add + re-sync fields; never remove
+	AutoImportSync   AutoImportMode = "sync"   // add + update + remove vanished
+)
+
+// NormalizeAutoImport lowercases and validates a mode, failing closed to
+// off (with a warning) for any unknown non-empty value so a typo can never
+// silently enable full sync.
+func NormalizeAutoImport(m AutoImportMode) AutoImportMode {
+	switch AutoImportMode(strings.ToLower(string(m))) {
+	case AutoImportAdd:
+		return AutoImportAdd
+	case AutoImportUpdate:
+		return AutoImportUpdate
+	case AutoImportSync:
+		return AutoImportSync
+	case AutoImportOff, "":
+		return AutoImportOff
+	default:
+		logging.Warn("Unknown discovery.docker.auto_import value; defaulting to off",
+			"source", "config", "value", string(m))
+		return AutoImportOff
+	}
+}
 
 // DiscoveryTLSConfig is the mTLS configuration used when the Docker
 // endpoint is a tcp:// address requiring certificate authentication.
@@ -680,6 +714,7 @@ func applyDiscoveryDefaults(cfg *Config) {
 	if d.HealthBadgePlacement == "" {
 		d.HealthBadgePlacement = "overview"
 	}
+	d.AutoImport = NormalizeAutoImport(d.AutoImport)
 }
 
 // expandBracedEnv replaces ${VAR} references with environment variable values.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -509,6 +509,10 @@ type AppConfig struct {
 	// hand-edited config.yaml, and Load() auto-detaches tracking
 	// so the operator's edit survives the next poller tick.
 	DockerManagedURL string `yaml:"docker_managed_url,omitempty" json:"docker_managed_url,omitempty"`
+	// DockerAutoImported marks an app the discovery reconciler created.
+	// Only such apps are updated or removed by auto-import; manually
+	// imported apps (DockerKey set, this false) are never touched.
+	DockerAutoImported bool `yaml:"docker_auto,omitempty" json:"docker_auto,omitempty"`
 }
 
 // AppIconConfig holds app icon settings
@@ -634,6 +638,34 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
+// detachIfHandEdited clears all Docker tracking fields on a single
+// AppConfig when URL no longer matches DockerManagedURL (the value
+// the poller last wrote). Empty DockerManagedURL is treated as "field
+// not yet recorded" and skipped so grandfathered configs keep their
+// tracking until the poller next writes the baseline.
+func detachIfHandEdited(app *AppConfig) {
+	if app.DockerKey == "" {
+		return
+	}
+	if app.DockerManagedURL == "" {
+		return // grandfather; poller hasn't recorded a baseline yet
+	}
+	if app.URL == app.DockerManagedURL {
+		return
+	}
+	logging.Info("Auto-detached app from Docker tracking due to operator URL edit in config.yaml",
+		"source", "config",
+		"app", app.Name,
+		"managed_url", app.DockerManagedURL,
+		"current_url", app.URL,
+		"previous_docker_key", app.DockerKey)
+	app.DockerKey = ""
+	app.DockerEndpoint = ""
+	app.DockerStrategy = ""
+	app.DockerManagedURL = ""
+	app.DockerAutoImported = false
+}
+
 // autoDetachEditedDockerEntries clears DockerKey/DockerEndpoint/
 // DockerStrategy on apps and gateway sites whose stored URL no
 // longer matches the value the poller last wrote (DockerManagedURL).
@@ -647,26 +679,7 @@ func Load(path string) (*Config, error) {
 // the field. Once recorded, comparisons start.
 func autoDetachEditedDockerEntries(cfg *Config) {
 	for i := range cfg.Apps {
-		app := &cfg.Apps[i]
-		if app.DockerKey == "" {
-			continue
-		}
-		if app.DockerManagedURL == "" {
-			continue // grandfather; poller hasn't recorded a baseline yet
-		}
-		if app.URL == app.DockerManagedURL {
-			continue
-		}
-		logging.Info("Auto-detached app from Docker tracking due to operator URL edit in config.yaml",
-			"source", "config",
-			"app", app.Name,
-			"managed_url", app.DockerManagedURL,
-			"current_url", app.URL,
-			"previous_docker_key", app.DockerKey)
-		app.DockerKey = ""
-		app.DockerEndpoint = ""
-		app.DockerStrategy = ""
-		app.DockerManagedURL = ""
+		detachIfHandEdited(&cfg.Apps[i])
 	}
 	for i := range cfg.Server.GatewaySites {
 		site := &cfg.Server.GatewaySites[i]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -609,6 +609,11 @@ func Load(path string) (*Config, error) {
 	// fine and we don't touch them.
 	applyDiscoveryDefaults(cfg)
 
+	// Direct environment override for the auto-import mode. Runs after
+	// applyDiscoveryDefaults (which normalizes the yaml value) so an
+	// operator-set MUXIMUX_DISCOVERY_AUTO_IMPORT wins over config.yaml.
+	ApplyAutoImportEnv(cfg, os.LookupEnv)
+
 	// Auto-migrate legacy server.gateway: (Caddyfile path) to the
 	// declarative server.gateway_sites: form. Runs once before
 	// validate() so the migrated sites participate in the same

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1745,3 +1745,20 @@ func TestDefaults_LifecycleMinRole_DefaultsToAdminWhenLifecycleEnabled(t *testin
 		t.Fatalf("want overview, got %q", c.Discovery.Docker.HealthBadgePlacement)
 	}
 }
+
+func TestNormalizeAutoImport(t *testing.T) {
+	cases := map[AutoImportMode]AutoImportMode{
+		"":        AutoImportOff, // absent defaults to off
+		"off":     AutoImportOff,
+		"add":     AutoImportAdd,
+		"update":  AutoImportUpdate,
+		"sync":    AutoImportSync,
+		"SYNC":    AutoImportSync,     // case-insensitive
+		"garbage": AutoImportOff,      // unknown fails closed
+	}
+	for in, want := range cases {
+		if got := NormalizeAutoImport(in); got != want {
+			t.Errorf("NormalizeAutoImport(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1753,8 +1753,8 @@ func TestNormalizeAutoImport(t *testing.T) {
 		"add":     AutoImportAdd,
 		"update":  AutoImportUpdate,
 		"sync":    AutoImportSync,
-		"SYNC":    AutoImportSync,     // case-insensitive
-		"garbage": AutoImportOff,      // unknown fails closed
+		"SYNC":    AutoImportSync, // case-insensitive
+		"garbage": AutoImportOff,  // unknown fails closed
 	}
 	for in, want := range cases {
 		if got := NormalizeAutoImport(in); got != want {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1762,3 +1762,18 @@ func TestNormalizeAutoImport(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadDetachClearsAutoImported(t *testing.T) {
+	// An auto-imported app whose URL was hand-edited (URL != DockerManagedURL)
+	// must detach: DockerKey and DockerAutoImported both cleared.
+	app := AppConfig{
+		Name: "Sonarr", URL: "http://edited:8989",
+		DockerKey: "label:sonarr", DockerManagedURL: "http://old:8989",
+		DockerAutoImported: true,
+	}
+	detachIfHandEdited(&app) // the helper Load() already calls
+	if app.DockerKey != "" || app.DockerAutoImported {
+		t.Errorf("expected detach to clear tracking, got key=%q auto=%v",
+			app.DockerKey, app.DockerAutoImported)
+	}
+}

--- a/internal/discovery/autoimport.go
+++ b/internal/discovery/autoimport.go
@@ -1,0 +1,142 @@
+package discovery
+
+import "github.com/mescon/muximux/v3/internal/config"
+
+// Desired is the config Muximux wants for one labeled container: the
+// app plus an optional gateway site when the container declares a
+// gateway domain. A nil Site means the container routes directly or via
+// the built-in path-prefix proxy and needs no Caddy site.
+type Desired struct {
+	App  config.AppConfig
+	Site *config.GatewaySite
+}
+
+// BuildDesired maps a label-derived Suggestion to the AppConfig (and
+// optional GatewaySite) that auto-import should materialize, deriving
+// routing from labels:
+//
+//   - SuggestedDomain set -> a gateway site fronts the container. The
+//     App.URL becomes the public domain (https unless tls=none), the
+//     App is NOT proxy-routed, and the GatewaySite forwards to the
+//     container URL. This mirrors handlers.ImportDocker's RoutingGateway
+//     branch for URL/Proxy/BackendURL.
+//   - else Proxy label true -> App.Proxy true (built-in reverse proxy).
+//   - else -> direct App pointing at the container URL.
+//
+// Tracking is stamped on every path so the auto-import reconciler owns
+// the entry and config.Load() can detect an operator hand-edit cleanly:
+// DockerManagedURL is seeded to the value stored in the matching URL
+// field (App.URL for the app, Site.BackendURL for the site), which is
+// the baseline detachIfHandEdited / autoDetachEditedDockerEntries
+// compare against.
+//
+// Divergence from ImportDocker, by design: manual gateway import detaches
+// the App (only the site is tracked) so the operator's gateway URL is
+// never rewritten. Auto-import instead keeps the App tracked (DockerKey
+// set, DockerAutoImported true) so the reconciler can remove the app
+// when the container disappears. The App.URL is the static gateway
+// domain and DockerManagedURL equals it, so no spurious detach or URL
+// rewrite results.
+func BuildDesired(sug Suggestion, endpoint string) Desired {
+	app := config.AppConfig{
+		Name:          sug.Name,
+		URL:           sug.URL,
+		HealthURL:     sug.HealthURL,
+		Icon:          config.AppIconConfig{Type: "dashboard", Name: sug.Icon},
+		Color:         sug.Color,
+		Group:         sug.Group,
+		Order:         sug.Order,
+		Enabled:       true,
+		OpenMode:      sug.OpenMode,
+		MinRole:       sug.MinRole,
+		AllowedGroups: sug.AllowedGroups,
+		Permissions:   sug.Permissions,
+		// Tracking. DockerManagedURL is set after routing decides the
+		// final App.URL (gateway routing rewrites it to the domain).
+		DockerKey:          sug.Key,
+		DockerEndpoint:     endpoint,
+		DockerStrategy:     string(sug.EffectiveStrategy),
+		DockerAutoImported: true,
+	}
+
+	if sug.Proxy != nil {
+		app.Proxy = *sug.Proxy
+	}
+	app.ProxySkipTLSVerify = sug.ProxySkipTLSVerify
+	if sug.AllowNotifications != nil {
+		app.AllowNotifications = *sug.AllowNotifications
+	}
+	if sug.Default != nil {
+		app.Default = *sug.Default
+	}
+	if sug.Shortcut != 0 {
+		s := sug.Shortcut
+		app.Shortcut = &s
+	}
+	app.HTTPActionMethod = sug.HTTPActionMethod
+	app.HTTPActionHeaders = sug.HTTPActionHeaders
+	if sug.HTTPActionConfirm != nil {
+		app.HTTPActionConfirm = *sug.HTTPActionConfirm
+	}
+	app.HTTPActionShowToast = sug.HTTPActionShowToast
+
+	d := Desired{}
+	if sug.SuggestedDomain != "" {
+		d.Site = buildGatewaySite(sug, endpoint)
+		// Gateway routing: the menu loads via the public hostname, so
+		// App.URL is the domain and the app is not proxy-routed. The
+		// gateway site forwards to the container URL (Site.BackendURL).
+		app.URL = gatewayScheme(d.Site.TLS) + "://" + sug.SuggestedDomain
+		app.Proxy = false
+		d.Site.AppName = app.Name
+	}
+
+	// Seed the clean-detach baseline to the final App.URL (the container
+	// URL for direct/proxy, the gateway domain for gateway routing).
+	app.DockerManagedURL = app.URL
+	d.App = app
+	return d
+}
+
+// buildGatewaySite mirrors the config.GatewaySite that a manual import
+// produces for the same container: domain from the label, backend
+// pointing at the container URL, the muximux.gateway.* fields copied
+// through, and the tracking + clean-detach baseline stamped.
+func buildGatewaySite(sug Suggestion, endpoint string) *config.GatewaySite {
+	site := config.GatewaySite{
+		Domain:     sug.SuggestedDomain,
+		BackendURL: sug.URL,
+		// Tracking. BackendURL is the URL the reconciler refreshes, so
+		// it is also the clean-detach baseline.
+		DockerKey:        sug.Key,
+		DockerEndpoint:   endpoint,
+		DockerStrategy:   string(sug.EffectiveStrategy),
+		DockerManagedURL: sug.URL,
+	}
+	if gw := sug.SuggestedGateway; gw != nil {
+		site.TLS = config.TLSMode(gw.TLS)
+		if gw.Streaming != nil {
+			site.Streaming = *gw.Streaming
+		}
+		if gw.StripFrameBlockers != nil {
+			site.StripFrameBlockers = *gw.StripFrameBlockers
+		}
+		site.ForwardedHeaders = gw.ForwardedHeaders
+		if gw.RequireAuth != nil {
+			site.RequireAuth = *gw.RequireAuth
+		}
+		site.MinRole = gw.MinRole
+		site.AllowedGroups = gw.AllowedGroups
+	}
+	return &site
+}
+
+// gatewayScheme picks the App.URL scheme for a gateway-fronted app:
+// https by default (Caddy issues a cert for auto/custom sites), http
+// only when the site is served without TLS. Mirrors ImportDocker.
+func gatewayScheme(tls config.TLSMode) string {
+	if tls == config.TLSModeNone {
+		return "http"
+	}
+	return "https"
+}

--- a/internal/discovery/autoimport.go
+++ b/internal/discovery/autoimport.go
@@ -1,6 +1,10 @@
 package discovery
 
-import "github.com/mescon/muximux/v3/internal/config"
+import (
+	"reflect"
+
+	"github.com/mescon/muximux/v3/internal/config"
+)
 
 // Desired is the config Muximux wants for one labeled container: the
 // app plus an optional gateway site when the container declares a
@@ -139,4 +143,99 @@ func gatewayScheme(tls config.TLSMode) string {
 		return "http"
 	}
 	return "https"
+}
+
+// ReconcilePlan is the set of changes auto-import wants to apply this
+// tick: apps to create, auto-imported apps to refresh in place, and the
+// DockerKeys of auto-imported apps whose containers have vanished.
+type ReconcilePlan struct {
+	Add        []Desired
+	Update     []Desired
+	RemoveKeys []string
+}
+
+// Reconcile diffs the desired set (from currently labeled containers)
+// against the current config apps by DockerKey. It is a pure function:
+// no config mutation, no I/O, output depends only on its inputs.
+//
+//   - off mode: empty plan, no work.
+//   - desired key with no current app: Add (every non-off mode).
+//   - desired key whose current app is auto-imported and differs in a
+//     label-controlled field: Update (update/sync only, never add mode).
+//   - desired key whose current app exists but is not auto-imported
+//     (manual or detached): left untouched; it still suppresses the Add
+//     so no duplicate app is created.
+//   - sync only: a current auto-imported app whose DockerKey is absent
+//     from the desired set has its key listed in RemoveKeys. Apps without
+//     DockerAutoImported are never updated or removed.
+func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.AppConfig) ReconcilePlan {
+	var plan ReconcilePlan
+	if mode == config.AutoImportOff {
+		return plan
+	}
+
+	curByKey := make(map[string]config.AppConfig, len(current))
+	for _, a := range current {
+		if a.DockerKey != "" {
+			curByKey[a.DockerKey] = a
+		}
+	}
+	desiredKeys := make(map[string]bool, len(desired))
+
+	for _, d := range desired {
+		k := d.App.DockerKey
+		desiredKeys[k] = true
+		cur, exists := curByKey[k]
+		switch {
+		case !exists:
+			plan.Add = append(plan.Add, d)
+		case cur.DockerAutoImported && mode != config.AutoImportAdd && !sameManagedFields(cur, d.App):
+			plan.Update = append(plan.Update, d)
+		default:
+			// Manual/detached app, add mode, or unchanged auto app:
+			// leave the current entry as-is.
+		}
+	}
+
+	if mode == config.AutoImportSync {
+		for _, a := range current {
+			if a.DockerAutoImported && a.DockerKey != "" && !desiredKeys[a.DockerKey] {
+				plan.RemoveKeys = append(plan.RemoveKeys, a.DockerKey)
+			}
+		}
+	}
+	return plan
+}
+
+// sameManagedFields reports whether two apps agree on every
+// label-controlled field that BuildDesired sets, i.e. the fields
+// auto-import owns. It deliberately ignores tracking bookkeeping
+// (DockerKey/Endpoint/Strategy/ManagedURL/AutoImported) and unrelated
+// operator state (AuthBypass, Access, HealthCheck, Scale, ProxyHeaders,
+// ForceIconBackground) so that a hand-set field elsewhere on an
+// auto-imported app never triggers a spurious Update. A blanket
+// reflect.DeepEqual over the whole AppConfig would compare those unowned
+// fields and report false differences, so the comparison is explicit.
+func sameManagedFields(a, b config.AppConfig) bool {
+	return a.Name == b.Name &&
+		a.URL == b.URL &&
+		a.HealthURL == b.HealthURL &&
+		a.Icon == b.Icon &&
+		a.Color == b.Color &&
+		a.Group == b.Group &&
+		a.Order == b.Order &&
+		a.Enabled == b.Enabled &&
+		a.Default == b.Default &&
+		a.OpenMode == b.OpenMode &&
+		a.Proxy == b.Proxy &&
+		a.MinRole == b.MinRole &&
+		a.AllowNotifications == b.AllowNotifications &&
+		a.HTTPActionMethod == b.HTTPActionMethod &&
+		a.HTTPActionConfirm == b.HTTPActionConfirm &&
+		reflect.DeepEqual(a.ProxySkipTLSVerify, b.ProxySkipTLSVerify) &&
+		reflect.DeepEqual(a.Shortcut, b.Shortcut) &&
+		reflect.DeepEqual(a.HTTPActionShowToast, b.HTTPActionShowToast) &&
+		reflect.DeepEqual(a.AllowedGroups, b.AllowedGroups) &&
+		reflect.DeepEqual(a.Permissions, b.Permissions) &&
+		reflect.DeepEqual(a.HTTPActionHeaders, b.HTTPActionHeaders)
 }

--- a/internal/discovery/autoimport.go
+++ b/internal/discovery/autoimport.go
@@ -41,7 +41,7 @@ type Desired struct {
 // when the container disappears. The App.URL is the static gateway
 // domain and DockerManagedURL equals it, so no spurious detach or URL
 // rewrite results.
-func BuildDesired(sug Suggestion, endpoint string) Desired {
+func BuildDesired(sug *Suggestion, endpoint string) Desired {
 	app := config.AppConfig{
 		Name:          sug.Name,
 		URL:           sug.URL,
@@ -106,7 +106,7 @@ func BuildDesired(sug Suggestion, endpoint string) Desired {
 // produces for the same container: domain from the label, backend
 // pointing at the container URL, the muximux.gateway.* fields copied
 // through, and the tracking + clean-detach baseline stamped.
-func buildGatewaySite(sug Suggestion, endpoint string) *config.GatewaySite {
+func buildGatewaySite(sug *Suggestion, endpoint string) *config.GatewaySite {
 	site := config.GatewaySite{
 		Domain:     sug.SuggestedDomain,
 		BackendURL: sug.URL,
@@ -178,22 +178,22 @@ func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.A
 	}
 
 	curByKey := make(map[string]config.AppConfig, len(current))
-	for _, a := range current {
-		if a.DockerKey != "" {
-			curByKey[a.DockerKey] = a
+	for i := range current {
+		if current[i].DockerKey != "" {
+			curByKey[current[i].DockerKey] = current[i]
 		}
 	}
 	desiredKeys := make(map[string]bool, len(desired))
 
-	for _, d := range desired {
-		k := d.App.DockerKey
+	for i := range desired {
+		k := desired[i].App.DockerKey
 		desiredKeys[k] = true
 		cur, exists := curByKey[k]
 		switch {
 		case !exists:
-			plan.Add = append(plan.Add, d)
-		case cur.DockerAutoImported && mode != config.AutoImportAdd && !sameManagedFields(cur, d.App):
-			plan.Update = append(plan.Update, d)
+			plan.Add = append(plan.Add, desired[i])
+		case cur.DockerAutoImported && mode != config.AutoImportAdd && !sameManagedFields(&cur, &desired[i].App):
+			plan.Update = append(plan.Update, desired[i])
 		default:
 			// Manual/detached app, add mode, or unchanged auto app:
 			// leave the current entry as-is.
@@ -201,9 +201,9 @@ func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.A
 	}
 
 	if mode == config.AutoImportSync {
-		for _, a := range current {
-			if a.DockerAutoImported && a.DockerKey != "" && !desiredKeys[a.DockerKey] {
-				plan.RemoveKeys = append(plan.RemoveKeys, a.DockerKey)
+		for i := range current {
+			if current[i].DockerAutoImported && current[i].DockerKey != "" && !desiredKeys[current[i].DockerKey] {
+				plan.RemoveKeys = append(plan.RemoveKeys, current[i].DockerKey)
 			}
 		}
 	}
@@ -219,7 +219,7 @@ func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.A
 // auto-imported app never triggers a spurious Update. A blanket
 // reflect.DeepEqual over the whole AppConfig would compare those unowned
 // fields and report false differences, so the comparison is explicit.
-func sameManagedFields(a, b config.AppConfig) bool {
+func sameManagedFields(a, b *config.AppConfig) bool {
 	return a.Name == b.Name &&
 		a.URL == b.URL &&
 		a.HealthURL == b.HealthURL &&

--- a/internal/discovery/autoimport.go
+++ b/internal/discovery/autoimport.go
@@ -132,6 +132,9 @@ func buildGatewaySite(sug Suggestion, endpoint string) *config.GatewaySite {
 		site.MinRole = gw.MinRole
 		site.AllowedGroups = gw.AllowedGroups
 	}
+	// ProxyHeaders, TLSCert, and TLSKey are intentionally left unset:
+	// there is no muximux.gateway.* label vocabulary for them, so auto-
+	// import cannot populate them (matches the manual import path).
 	return &site
 }
 

--- a/internal/discovery/autoimport_test.go
+++ b/internal/discovery/autoimport_test.go
@@ -1,0 +1,284 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/mescon/muximux/v3/internal/config"
+)
+
+// TestBuildDesired_ProxyApp: a container with the proxy label set and
+// no gateway domain must produce a proxied App and no GatewaySite,
+// with tracking stamped and a clean detach baseline.
+func TestBuildDesired_ProxyApp(t *testing.T) {
+	yes := true
+	sug := Suggestion{
+		Key: "label:sonarr", Name: "Sonarr", URL: "http://10.0.0.5:8989",
+		Icon: "sonarr", Group: "Media", HealthURL: "http://10.0.0.5:8989/api/v3/health",
+		EffectiveStrategy: config.StrategyContainerIP,
+		Color:             "#3498db", Order: 10, OpenMode: "iframe", Proxy: &yes,
+		MinRole: "user", AllowedGroups: []string{"family", "admins"},
+	}
+	d := BuildDesired(sug, "unix:///var/run/docker.sock")
+
+	if d.Site != nil {
+		t.Fatalf("no gateway domain -> no site, got %+v", d.Site)
+	}
+	if !d.App.Proxy {
+		t.Error("Proxy label true -> App.Proxy true")
+	}
+	if d.App.DockerKey != "label:sonarr" || !d.App.DockerAutoImported {
+		t.Errorf("tracking not set: key=%q auto=%v", d.App.DockerKey, d.App.DockerAutoImported)
+	}
+	if d.App.DockerEndpoint != "unix:///var/run/docker.sock" {
+		t.Errorf("endpoint not carried: %q", d.App.DockerEndpoint)
+	}
+	if d.App.DockerStrategy != string(config.StrategyContainerIP) {
+		t.Errorf("strategy not carried: %q", d.App.DockerStrategy)
+	}
+	if d.App.DockerManagedURL != d.App.URL {
+		t.Errorf("managed URL must equal URL for clean detach detection: %q != %q", d.App.DockerManagedURL, d.App.URL)
+	}
+	if d.App.URL != "http://10.0.0.5:8989" {
+		t.Errorf("URL = %q", d.App.URL)
+	}
+	if d.App.HealthURL != "http://10.0.0.5:8989/api/v3/health" {
+		t.Errorf("health url not carried: %q", d.App.HealthURL)
+	}
+	if d.App.Icon.Type != "dashboard" || d.App.Icon.Name != "sonarr" {
+		t.Errorf("icon = %+v", d.App.Icon)
+	}
+	if !d.App.Enabled {
+		t.Error("app should be enabled")
+	}
+	if d.App.Name != "Sonarr" || d.App.Group != "Media" || d.App.MinRole != "user" {
+		t.Error("label-derived fields not carried through")
+	}
+	if len(d.App.AllowedGroups) != 2 {
+		t.Errorf("allowed groups = %v", d.App.AllowedGroups)
+	}
+}
+
+// TestBuildDesired_DirectApp: no proxy label and no gateway domain ->
+// a direct App (Proxy false), tracked, no Site.
+func TestBuildDesired_DirectApp(t *testing.T) {
+	sug := Suggestion{
+		Key: "name:grafana", Name: "Grafana", URL: "http://10.0.0.9:3000",
+		EffectiveStrategy: config.StrategyContainerIP,
+	}
+	d := BuildDesired(sug, "tcp://docker:2375")
+
+	if d.Site != nil {
+		t.Fatalf("no gateway domain -> no site, got %+v", d.Site)
+	}
+	if d.App.Proxy {
+		t.Error("no proxy label -> App.Proxy false")
+	}
+	if d.App.DockerKey != "name:grafana" || !d.App.DockerAutoImported {
+		t.Errorf("tracking not set: key=%q auto=%v", d.App.DockerKey, d.App.DockerAutoImported)
+	}
+	if d.App.DockerManagedURL != d.App.URL {
+		t.Errorf("managed URL must equal URL: %q != %q", d.App.DockerManagedURL, d.App.URL)
+	}
+}
+
+// TestBuildDesired_NilProxyIsDirect: a Suggestion with Proxy nil (no
+// proxy label at all) must default App.Proxy to false.
+func TestBuildDesired_NilProxyIsDirect(t *testing.T) {
+	sug := Suggestion{Key: "id:abc", Name: "App", URL: "http://h:1"}
+	d := BuildDesired(sug, "e")
+	if d.App.Proxy {
+		t.Error("nil Proxy -> App.Proxy must be false")
+	}
+	if d.App.ProxySkipTLSVerify != nil {
+		t.Error("nil ProxySkipTLSVerify must stay nil")
+	}
+}
+
+// TestBuildDesired_GatewaySite: a SuggestedDomain plus a gateway label
+// set must produce a GatewaySite mirroring ImportDocker: BackendURL is
+// the container URL, App.URL becomes the public domain, App.Proxy is
+// false, both App and Site are tracked, and the Site's clean-detach
+// baseline equals its BackendURL.
+func TestBuildDesired_GatewaySite(t *testing.T) {
+	yes := true
+	no := false
+	sug := Suggestion{
+		Key: "label:sonarr", Name: "Sonarr", URL: "http://10.0.0.5:8989",
+		EffectiveStrategy: config.StrategyContainerIP,
+		SuggestedDomain:   "sonarr.example.com",
+		SuggestedGateway: &SuggestedGatewayConfig{
+			TLS:                "auto",
+			Streaming:          &yes,
+			StripFrameBlockers: &yes,
+			ForwardedHeaders:   &no,
+			RequireAuth:        &yes,
+			MinRole:            "power-user",
+			AllowedGroups:      []string{"staff"},
+		},
+	}
+	d := BuildDesired(sug, "unix:///x")
+	if d.Site == nil {
+		t.Fatal("gateway domain -> gateway site expected")
+	}
+	if d.Site.Domain != "sonarr.example.com" {
+		t.Errorf("site domain = %q", d.Site.Domain)
+	}
+	if d.Site.BackendURL != "http://10.0.0.5:8989" {
+		t.Errorf("site backend must be the container URL, got %q", d.Site.BackendURL)
+	}
+	if d.Site.TLS != config.TLSModeAuto {
+		t.Errorf("site tls = %q", d.Site.TLS)
+	}
+	if d.Site.Streaming != true || d.Site.StripFrameBlockers != true {
+		t.Errorf("streaming=%v stripframe=%v", d.Site.Streaming, d.Site.StripFrameBlockers)
+	}
+	if d.Site.ForwardedHeaders == nil || *d.Site.ForwardedHeaders != false {
+		t.Errorf("forwarded headers = %v", d.Site.ForwardedHeaders)
+	}
+	if !d.Site.RequireAuth || d.Site.MinRole != "power-user" || len(d.Site.AllowedGroups) != 1 {
+		t.Errorf("auth gate not mapped: %+v", d.Site)
+	}
+	if d.Site.DockerKey != "label:sonarr" {
+		t.Errorf("site must carry tracking key, got %q", d.Site.DockerKey)
+	}
+	if d.Site.DockerEndpoint != "unix:///x" || d.Site.DockerStrategy != string(config.StrategyContainerIP) {
+		t.Errorf("site tracking incomplete: %+v", d.Site)
+	}
+	if d.Site.DockerManagedURL != d.Site.BackendURL {
+		t.Errorf("site managed URL must equal backend URL: %q != %q", d.Site.DockerManagedURL, d.Site.BackendURL)
+	}
+	if d.Site.AppName != "Sonarr" {
+		t.Errorf("site must link to the app: %q", d.Site.AppName)
+	}
+
+	// App side: URL becomes the public https domain, proxy off.
+	if d.App.URL != "https://sonarr.example.com" {
+		t.Errorf("gateway app URL = %q, want https://sonarr.example.com", d.App.URL)
+	}
+	if d.App.Proxy {
+		t.Error("gateway app must not be proxy-routed")
+	}
+	if d.App.DockerKey != "label:sonarr" || !d.App.DockerAutoImported {
+		t.Errorf("gateway app tracking not set: %+v", d.App)
+	}
+	if d.App.DockerManagedURL != d.App.URL {
+		t.Errorf("gateway app managed URL must equal URL: %q != %q", d.App.DockerManagedURL, d.App.URL)
+	}
+}
+
+// TestBuildDesired_GatewayTLSNone: TLS=none means the public app URL is
+// plain http (mirrors ImportDocker's scheme selection).
+func TestBuildDesired_GatewayTLSNone(t *testing.T) {
+	sug := Suggestion{
+		Key: "label:x", Name: "X", URL: "http://h:1",
+		SuggestedDomain:  "x.example.com",
+		SuggestedGateway: &SuggestedGatewayConfig{TLS: "none"},
+	}
+	d := BuildDesired(sug, "e")
+	if d.Site == nil {
+		t.Fatal("expected site")
+	}
+	if d.Site.TLS != config.TLSModeNone {
+		t.Errorf("tls = %q", d.Site.TLS)
+	}
+	if d.App.URL != "http://x.example.com" {
+		t.Errorf("tls=none -> http app URL, got %q", d.App.URL)
+	}
+}
+
+// TestBuildDesired_GatewayNilConfig: a domain with no muximux.gateway.*
+// labels (SuggestedGateway nil) still builds a Site with defaults and
+// an https app URL, without panicking.
+func TestBuildDesired_GatewayNilConfig(t *testing.T) {
+	sug := Suggestion{
+		Key: "label:y", Name: "Y", URL: "http://h:2",
+		SuggestedDomain: "y.example.com",
+	}
+	d := BuildDesired(sug, "e")
+	if d.Site == nil {
+		t.Fatal("domain present -> site expected even without gateway labels")
+	}
+	if d.Site.Domain != "y.example.com" || d.Site.BackendURL != "http://h:2" {
+		t.Errorf("site = %+v", d.Site)
+	}
+	if d.Site.TLS != config.TLSModeDefault {
+		t.Errorf("default tls expected, got %q", d.Site.TLS)
+	}
+	if d.Site.RequireAuth || d.Site.Streaming || d.Site.StripFrameBlockers {
+		t.Errorf("defaults should be off: %+v", d.Site)
+	}
+	if d.Site.ForwardedHeaders != nil {
+		t.Errorf("forwarded headers should stay nil when unset, got %v", d.Site.ForwardedHeaders)
+	}
+	if d.App.URL != "https://y.example.com" {
+		t.Errorf("default scheme https, got %q", d.App.URL)
+	}
+}
+
+// TestBuildDesired_CarriesAllLabelFields asserts every label-derived
+// Suggestion field with a value lands on the AppConfig. Guards against
+// future divergence from manual import.
+func TestBuildDesired_CarriesAllLabelFields(t *testing.T) {
+	no := false
+	yes := true
+	shortcut := 3
+	sug := Suggestion{
+		Key: "label:x", Name: "X", URL: "http://h:1", OpenMode: "redirect",
+		Color: "#fff", Order: 7, MinRole: "admin",
+		AllowedGroups: []string{"g"}, Permissions: []string{"clipboard-read"},
+		Proxy: &no, ProxySkipTLSVerify: &no,
+		AllowNotifications:  &yes,
+		Default:             &yes,
+		Shortcut:            shortcut,
+		HTTPActionMethod:    "POST",
+		HTTPActionHeaders:   map[string]string{"X-Api": "k"},
+		HTTPActionConfirm:   &yes,
+		HTTPActionShowToast: &no,
+	}
+	d := BuildDesired(sug, "e")
+	a := d.App
+	if a.OpenMode != "redirect" || a.Color != "#fff" || a.Order != 7 ||
+		a.MinRole != "admin" || len(a.AllowedGroups) != 1 ||
+		len(a.Permissions) != 1 || a.Proxy {
+		t.Errorf("label field dropped: %+v", a)
+	}
+	if a.ProxySkipTLSVerify == nil || *a.ProxySkipTLSVerify != false {
+		t.Errorf("proxy skip tls verify = %v", a.ProxySkipTLSVerify)
+	}
+	if !a.AllowNotifications {
+		t.Error("allow notifications dropped")
+	}
+	if !a.Default {
+		t.Error("default dropped")
+	}
+	if a.Shortcut == nil || *a.Shortcut != 3 {
+		t.Errorf("shortcut = %v", a.Shortcut)
+	}
+	if a.HTTPActionMethod != "POST" || len(a.HTTPActionHeaders) != 1 {
+		t.Errorf("http action method/headers dropped: %+v", a)
+	}
+	if !a.HTTPActionConfirm {
+		t.Error("http action confirm dropped")
+	}
+	if a.HTTPActionShowToast == nil || *a.HTTPActionShowToast != false {
+		t.Errorf("http action show toast = %v", a.HTTPActionShowToast)
+	}
+}
+
+// TestBuildDesired_OptionalPointersUnset: when the optional pointer and
+// scalar fields are unset, the App keeps Go zero values (no spurious
+// non-nil pointers, no shortcut).
+func TestBuildDesired_OptionalPointersUnset(t *testing.T) {
+	sug := Suggestion{Key: "k", Name: "N", URL: "http://h:1"}
+	d := BuildDesired(sug, "e")
+	a := d.App
+	if a.AllowNotifications || a.Default || a.HTTPActionConfirm {
+		t.Error("unset bool pointers must yield false")
+	}
+	if a.Shortcut != nil {
+		t.Errorf("unset shortcut must stay nil, got %v", a.Shortcut)
+	}
+	if a.HTTPActionShowToast != nil {
+		t.Errorf("unset show toast must stay nil, got %v", a.HTTPActionShowToast)
+	}
+}

--- a/internal/discovery/autoimport_test.go
+++ b/internal/discovery/autoimport_test.go
@@ -282,3 +282,172 @@ func TestBuildDesired_OptionalPointersUnset(t *testing.T) {
 		t.Errorf("unset show toast must stay nil, got %v", a.HTTPActionShowToast)
 	}
 }
+
+// --- Reconcile diff tests ---
+
+// key builds a manual app (DockerKey set, not auto-imported).
+func key(k string) config.AppConfig { return config.AppConfig{Name: k, DockerKey: k} }
+
+// autoKey builds an auto-imported app for key k.
+func autoKey(k string) config.AppConfig {
+	a := key(k)
+	a.DockerAutoImported = true
+	return a
+}
+
+// desire builds the Desired an auto-import tick wants for key k.
+func desire(k string) Desired {
+	return BuildDesired(Suggestion{Key: k, Name: k, URL: "http://h:1"}, "e")
+}
+
+// TestReconcile_Off: off mode is a no-op regardless of inputs.
+func TestReconcile_Off(t *testing.T) {
+	p := Reconcile(config.AutoImportOff, []Desired{desire("a")}, []config.AppConfig{autoKey("gone")})
+	if len(p.Add) != 0 || len(p.Update) != 0 || len(p.RemoveKeys) != 0 {
+		t.Errorf("off mode must be a no-op: %+v", p)
+	}
+}
+
+// TestReconcile_Modes covers add, sync-only removal, and manual-app
+// handling across modes.
+func TestReconcile_Modes(t *testing.T) {
+	// add: new key with no current app -> Add, in every non-off mode
+	for _, m := range []config.AutoImportMode{config.AutoImportAdd, config.AutoImportUpdate, config.AutoImportSync} {
+		p := Reconcile(m, []Desired{desire("a")}, nil)
+		if len(p.Add) != 1 || len(p.Update) != 0 || len(p.RemoveKeys) != 0 {
+			t.Errorf("%s add: %+v", m, p)
+		}
+	}
+
+	// vanished auto app: removed only in sync
+	cur := []config.AppConfig{autoKey("gone")}
+	if p := Reconcile(config.AutoImportAdd, nil, cur); len(p.RemoveKeys) != 0 {
+		t.Errorf("add must not remove: %+v", p)
+	}
+	if p := Reconcile(config.AutoImportUpdate, nil, cur); len(p.RemoveKeys) != 0 {
+		t.Errorf("update must not remove: %+v", p)
+	}
+	if p := Reconcile(config.AutoImportSync, nil, cur); len(p.RemoveKeys) != 1 || p.RemoveKeys[0] != "gone" {
+		t.Errorf("sync must remove vanished auto app: %+v", p)
+	}
+
+	// manual app present for a key: never removed, never duplicated
+	man := []config.AppConfig{key("m")} // no DockerAutoImported
+	p := Reconcile(config.AutoImportSync, []Desired{desire("m")}, man)
+	if len(p.Add) != 0 || len(p.Update) != 0 || len(p.RemoveKeys) != 0 {
+		t.Errorf("manual app must be untouched and block add: %+v", p)
+	}
+	// and a manual app whose container vanished is NOT removed in sync
+	p = Reconcile(config.AutoImportSync, nil, man)
+	if len(p.RemoveKeys) != 0 {
+		t.Errorf("sync must not remove a manual app: %+v", p)
+	}
+}
+
+// TestReconcile_DetachedAppNotRecreated: a detached app (DockerKey set,
+// DockerAutoImported false) suppresses an Add and is never updated, even
+// when the desired app's label fields differ from it.
+func TestReconcile_DetachedAppNotRecreated(t *testing.T) {
+	detached := key("d") // DockerKey set, auto false; differs from desire("d")
+	p := Reconcile(config.AutoImportSync, []Desired{desire("d")}, []config.AppConfig{detached})
+	if len(p.Add) != 0 {
+		t.Errorf("detached app must suppress add: %+v", p)
+	}
+	if len(p.Update) != 0 {
+		t.Errorf("detached app must not be updated: %+v", p)
+	}
+	if len(p.RemoveKeys) != 0 {
+		t.Errorf("detached app must not be removed: %+v", p)
+	}
+}
+
+// TestReconcile_UpdateOnlyWhenChanged: an auto app is updated only when a
+// label-controlled field actually differs, and never in add mode.
+func TestReconcile_UpdateOnlyWhenChanged(t *testing.T) {
+	cur := BuildDesired(Suggestion{Key: "u", Name: "U", URL: "http://h:1"}, "e").App
+	cur.DockerAutoImported = true
+	// identical desired -> no update
+	same := []Desired{{App: cur}}
+	if p := Reconcile(config.AutoImportUpdate, same, []config.AppConfig{cur}); len(p.Update) != 0 {
+		t.Errorf("unchanged should not update: %+v", p)
+	}
+	// changed name -> update
+	changed := BuildDesired(Suggestion{Key: "u", Name: "U2", URL: "http://h:1"}, "e")
+	if p := Reconcile(config.AutoImportUpdate, []Desired{changed}, []config.AppConfig{cur}); len(p.Update) != 1 {
+		t.Errorf("changed should update: %+v", p)
+	}
+	if p := Reconcile(config.AutoImportSync, []Desired{changed}, []config.AppConfig{cur}); len(p.Update) != 1 {
+		t.Errorf("sync should update changed app: %+v", p)
+	}
+	// update suppressed in add mode even when changed
+	if p := Reconcile(config.AutoImportAdd, []Desired{changed}, []config.AppConfig{cur}); len(p.Update) != 0 {
+		t.Errorf("add mode must not update: %+v", p)
+	}
+}
+
+// TestSameManagedFields covers each label-controlled field flipping the
+// result, and confirms unrelated state (AuthBypass/Access/tracking) does
+// not. Without this, a blanket DeepEqual would report false differences.
+func TestSameManagedFields(t *testing.T) {
+	base := BuildDesired(Suggestion{
+		Key: "s", Name: "S", URL: "http://h:1", HealthURL: "http://h:1/health",
+		Icon: "icon", Color: "#fff", Group: "g", Order: 3, OpenMode: "iframe",
+		MinRole: "admin", AllowedGroups: []string{"x"}, Permissions: []string{"camera"},
+		Proxy: boolPtr(true), ProxySkipTLSVerify: boolPtr(true),
+		AllowNotifications: boolPtr(true), Default: boolPtr(true), Shortcut: 4,
+		HTTPActionMethod: "POST", HTTPActionHeaders: map[string]string{"A": "b"},
+		HTTPActionConfirm: boolPtr(true), HTTPActionShowToast: boolPtr(false),
+	}, "e").App
+
+	if !sameManagedFields(base, base) {
+		t.Fatal("identical apps must be same")
+	}
+
+	// Unrelated, non-label state must NOT register as a difference.
+	unrelated := base
+	unrelated.AuthBypass = []config.AuthBypassRule{{}}
+	unrelated.Access = config.AppAccessConfig{Roles: []string{"admin"}}
+	unrelated.DockerEndpoint = "other"
+	unrelated.DockerStrategy = "other"
+	unrelated.DockerManagedURL = "http://changed"
+	unrelated.HealthCheck = boolPtr(true)
+	unrelated.Scale = 2
+	if !sameManagedFields(base, unrelated) {
+		t.Errorf("unrelated fields must not register as managed difference")
+	}
+
+	// Each label-controlled field, flipped, must register a difference.
+	mutators := map[string]func(*config.AppConfig){
+		"Name":                func(a *config.AppConfig) { a.Name = "z" },
+		"URL":                 func(a *config.AppConfig) { a.URL = "z" },
+		"HealthURL":           func(a *config.AppConfig) { a.HealthURL = "z" },
+		"Icon":                func(a *config.AppConfig) { a.Icon.Name = "z" },
+		"Color":               func(a *config.AppConfig) { a.Color = "z" },
+		"Group":               func(a *config.AppConfig) { a.Group = "z" },
+		"Order":               func(a *config.AppConfig) { a.Order = 99 },
+		"Enabled":             func(a *config.AppConfig) { a.Enabled = false },
+		"OpenMode":            func(a *config.AppConfig) { a.OpenMode = "new_tab" },
+		"Proxy":               func(a *config.AppConfig) { a.Proxy = false },
+		"ProxySkipTLSVerify":  func(a *config.AppConfig) { a.ProxySkipTLSVerify = boolPtr(false) },
+		"MinRole":             func(a *config.AppConfig) { a.MinRole = "user" },
+		"AllowedGroups":       func(a *config.AppConfig) { a.AllowedGroups = []string{"y"} },
+		"Permissions":         func(a *config.AppConfig) { a.Permissions = []string{"midi"} },
+		"AllowNotifications":  func(a *config.AppConfig) { a.AllowNotifications = false },
+		"Default":             func(a *config.AppConfig) { a.Default = false },
+		"Shortcut":            func(a *config.AppConfig) { a.Shortcut = intPtr(9) },
+		"HTTPActionMethod":    func(a *config.AppConfig) { a.HTTPActionMethod = "GET" },
+		"HTTPActionHeaders":   func(a *config.AppConfig) { a.HTTPActionHeaders = map[string]string{"C": "d"} },
+		"HTTPActionConfirm":   func(a *config.AppConfig) { a.HTTPActionConfirm = false },
+		"HTTPActionShowToast": func(a *config.AppConfig) { a.HTTPActionShowToast = boolPtr(true) },
+	}
+	for name, mut := range mutators {
+		mod := base
+		mut(&mod)
+		if sameManagedFields(base, mod) {
+			t.Errorf("flipping %s must register as a managed difference", name)
+		}
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+func intPtr(i int) *int    { return &i }

--- a/internal/discovery/autoimport_test.go
+++ b/internal/discovery/autoimport_test.go
@@ -18,7 +18,7 @@ func TestBuildDesired_ProxyApp(t *testing.T) {
 		Color:             "#3498db", Order: 10, OpenMode: "iframe", Proxy: &yes,
 		MinRole: "user", AllowedGroups: []string{"family", "admins"},
 	}
-	d := BuildDesired(sug, "unix:///var/run/docker.sock")
+	d := BuildDesired(&sug, "unix:///var/run/docker.sock")
 
 	if d.Site != nil {
 		t.Fatalf("no gateway domain -> no site, got %+v", d.Site)
@@ -65,7 +65,7 @@ func TestBuildDesired_DirectApp(t *testing.T) {
 		Key: "name:grafana", Name: "Grafana", URL: "http://10.0.0.9:3000",
 		EffectiveStrategy: config.StrategyContainerIP,
 	}
-	d := BuildDesired(sug, "tcp://docker:2375")
+	d := BuildDesired(&sug, "tcp://docker:2375")
 
 	if d.Site != nil {
 		t.Fatalf("no gateway domain -> no site, got %+v", d.Site)
@@ -85,7 +85,7 @@ func TestBuildDesired_DirectApp(t *testing.T) {
 // proxy label at all) must default App.Proxy to false.
 func TestBuildDesired_NilProxyIsDirect(t *testing.T) {
 	sug := Suggestion{Key: "id:abc", Name: "App", URL: "http://h:1"}
-	d := BuildDesired(sug, "e")
+	d := BuildDesired(&sug, "e")
 	if d.App.Proxy {
 		t.Error("nil Proxy -> App.Proxy must be false")
 	}
@@ -116,7 +116,7 @@ func TestBuildDesired_GatewaySite(t *testing.T) {
 			AllowedGroups:      []string{"staff"},
 		},
 	}
-	d := BuildDesired(sug, "unix:///x")
+	d := BuildDesired(&sug, "unix:///x")
 	if d.Site == nil {
 		t.Fatal("gateway domain -> gateway site expected")
 	}
@@ -174,7 +174,7 @@ func TestBuildDesired_GatewayTLSNone(t *testing.T) {
 		SuggestedDomain:  "x.example.com",
 		SuggestedGateway: &SuggestedGatewayConfig{TLS: "none"},
 	}
-	d := BuildDesired(sug, "e")
+	d := BuildDesired(&sug, "e")
 	if d.Site == nil {
 		t.Fatal("expected site")
 	}
@@ -194,7 +194,7 @@ func TestBuildDesired_GatewayNilConfig(t *testing.T) {
 		Key: "label:y", Name: "Y", URL: "http://h:2",
 		SuggestedDomain: "y.example.com",
 	}
-	d := BuildDesired(sug, "e")
+	d := BuildDesired(&sug, "e")
 	if d.Site == nil {
 		t.Fatal("domain present -> site expected even without gateway labels")
 	}
@@ -235,7 +235,7 @@ func TestBuildDesired_CarriesAllLabelFields(t *testing.T) {
 		HTTPActionConfirm:   &yes,
 		HTTPActionShowToast: &no,
 	}
-	d := BuildDesired(sug, "e")
+	d := BuildDesired(&sug, "e")
 	a := d.App
 	if a.OpenMode != "redirect" || a.Color != "#fff" || a.Order != 7 ||
 		a.MinRole != "admin" || len(a.AllowedGroups) != 1 ||
@@ -270,7 +270,7 @@ func TestBuildDesired_CarriesAllLabelFields(t *testing.T) {
 // non-nil pointers, no shortcut).
 func TestBuildDesired_OptionalPointersUnset(t *testing.T) {
 	sug := Suggestion{Key: "k", Name: "N", URL: "http://h:1"}
-	d := BuildDesired(sug, "e")
+	d := BuildDesired(&sug, "e")
 	a := d.App
 	if a.AllowNotifications || a.Default || a.HTTPActionConfirm {
 		t.Error("unset bool pointers must yield false")
@@ -297,7 +297,7 @@ func autoKey(k string) config.AppConfig {
 
 // desire builds the Desired an auto-import tick wants for key k.
 func desire(k string) Desired {
-	return BuildDesired(Suggestion{Key: k, Name: k, URL: "http://h:1"}, "e")
+	return BuildDesired(&Suggestion{Key: k, Name: k, URL: "http://h:1"}, "e")
 }
 
 // TestReconcile_Off: off mode is a no-op regardless of inputs.
@@ -364,7 +364,7 @@ func TestReconcile_DetachedAppNotRecreated(t *testing.T) {
 // TestReconcile_UpdateOnlyWhenChanged: an auto app is updated only when a
 // label-controlled field actually differs, and never in add mode.
 func TestReconcile_UpdateOnlyWhenChanged(t *testing.T) {
-	cur := BuildDesired(Suggestion{Key: "u", Name: "U", URL: "http://h:1"}, "e").App
+	cur := BuildDesired(&Suggestion{Key: "u", Name: "U", URL: "http://h:1"}, "e").App
 	cur.DockerAutoImported = true
 	// identical desired -> no update
 	same := []Desired{{App: cur}}
@@ -372,7 +372,7 @@ func TestReconcile_UpdateOnlyWhenChanged(t *testing.T) {
 		t.Errorf("unchanged should not update: %+v", p)
 	}
 	// changed name -> update
-	changed := BuildDesired(Suggestion{Key: "u", Name: "U2", URL: "http://h:1"}, "e")
+	changed := BuildDesired(&Suggestion{Key: "u", Name: "U2", URL: "http://h:1"}, "e")
 	if p := Reconcile(config.AutoImportUpdate, []Desired{changed}, []config.AppConfig{cur}); len(p.Update) != 1 {
 		t.Errorf("changed should update: %+v", p)
 	}
@@ -389,7 +389,7 @@ func TestReconcile_UpdateOnlyWhenChanged(t *testing.T) {
 // result, and confirms unrelated state (AuthBypass/Access/tracking) does
 // not. Without this, a blanket DeepEqual would report false differences.
 func TestSameManagedFields(t *testing.T) {
-	base := BuildDesired(Suggestion{
+	base := BuildDesired(&Suggestion{
 		Key: "s", Name: "S", URL: "http://h:1", HealthURL: "http://h:1/health",
 		Icon: "icon", Color: "#fff", Group: "g", Order: 3, OpenMode: "iframe",
 		MinRole: "admin", AllowedGroups: []string{"x"}, Permissions: []string{"camera"},
@@ -399,7 +399,7 @@ func TestSameManagedFields(t *testing.T) {
 		HTTPActionConfirm: boolPtr(true), HTTPActionShowToast: boolPtr(false),
 	}, "e").App
 
-	if !sameManagedFields(base, base) {
+	if !sameManagedFields(&base, &base) {
 		t.Fatal("identical apps must be same")
 	}
 
@@ -412,7 +412,7 @@ func TestSameManagedFields(t *testing.T) {
 	unrelated.DockerManagedURL = "http://changed"
 	unrelated.HealthCheck = boolPtr(true)
 	unrelated.Scale = 2
-	if !sameManagedFields(base, unrelated) {
+	if !sameManagedFields(&base, &unrelated) {
 		t.Errorf("unrelated fields must not register as managed difference")
 	}
 
@@ -443,7 +443,7 @@ func TestSameManagedFields(t *testing.T) {
 	for name, mut := range mutators {
 		mod := base
 		mut(&mod)
-		if sameManagedFields(base, mod) {
+		if sameManagedFields(&base, &mod) {
 			t.Errorf("flipping %s must register as a managed difference", name)
 		}
 	}

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -165,14 +165,37 @@ func (p *Poller) tick(ctx context.Context) {
 	enabled := p.deps.Config.Discovery.Docker.Enabled
 	endpoint := p.deps.Config.Discovery.Docker.Endpoint
 	hostIP := p.deps.Config.Discovery.Docker.HostIP
+	autoImport := p.deps.Config.Discovery.Docker.AutoImport
+	dashboardDomain := p.deps.Config.Server.TLS.Domain
 	tracked := p.collectTracked()
+	// Snapshot the current apps for the reconcile diff while we hold the
+	// read lock. Only needed when auto-import is active.
+	var currentApps []config.AppConfig
+	if autoImport != config.AutoImportOff {
+		currentApps = append([]config.AppConfig(nil), p.deps.Config.Apps...)
+	}
 	p.deps.ConfigMu.RUnlock()
 
 	if !enabled {
 		return
 	}
-	if len(tracked.apps) == 0 && len(tracked.sites) == 0 {
+	// Proceed when something is tracked OR auto-import is on. Auto-import
+	// must run before anything is tracked (the first boot of a declared
+	// container). Only bail when there is nothing to refresh AND no
+	// auto-import to perform.
+	if len(tracked.apps) == 0 && len(tracked.sites) == 0 && autoImport == config.AutoImportOff {
 		return // nothing to do
+	}
+
+	// Keys of tracked gateway sites. A tracked app sharing a key with a
+	// gateway site is gateway-routed: its URL is the static public domain,
+	// not a container URL, so the refresh pass must NOT resolve/rewrite it
+	// (doing so would clobber the domain and break routing). The sibling
+	// site's BackendURL refresh below keeps routing pointed at the live
+	// container.
+	gatewaySiteKeys := make(map[string]bool, len(tracked.sites))
+	for i := range tracked.sites {
+		gatewaySiteKeys[tracked.sites[i].key] = true
 	}
 
 	svc := p.deps.Service
@@ -204,6 +227,13 @@ func (p *Poller) tick(ctx context.Context) {
 	for i := range tracked.apps {
 		t := &tracked.apps[i]
 		if t.endpoint != endpoint {
+			continue
+		}
+		// Gateway-routed app: URL is the static gateway domain, not a
+		// container URL. Skip resolution so the domain is preserved; the
+		// sibling gateway site's BackendURL refresh (below) handles the
+		// container IP change.
+		if gatewaySiteKeys[t.key] {
 			continue
 		}
 		newURL, err := p.resolveURLFrom(containers, t.key, t.strategy, hostIP)
@@ -247,6 +277,42 @@ func (p *Poller) tick(ctx context.Context) {
 		if newURL != t.currentURL {
 			batch.siteURLChanges[t.domain] = newURL
 		}
+	}
+
+	// Auto-import reconcile. Scan the daemon for labeled containers, map
+	// each Suggestion to its Desired config, diff against the current
+	// apps, and fold the resulting plan into the SAME batch so the
+	// refresh and the auto-import commit atomically (one SaveConfig, one
+	// rollback) in applyRefreshBatch below.
+	//
+	// Known, deliberate limitation (approved design): Reconcile's Update
+	// only detects APP-field changes. gateway.domain / gateway.tls change
+	// App.URL so they DO propagate. But a change to a gateway-ONLY field
+	// (require_auth, min_role, streaming, strip_frame_blockers,
+	// forwarded_headers) that leaves every app field unchanged will NOT
+	// trigger an Update, so that site-field change does not propagate
+	// until the container is removed and re-added. We intentionally do
+	// NOT gateway-site field-diff here; update mode re-syncs app fields.
+	if autoImport != config.AutoImportOff {
+		scan := svc.Scan(ctx, dashboardDomain)
+		desired := make([]Desired, 0, len(scan.Suggestions))
+		for i := range scan.Suggestions {
+			desired = append(desired, BuildDesired(scan.Suggestions[i], endpoint))
+		}
+		plan := Reconcile(autoImport, desired, currentApps)
+		for _, d := range plan.Add {
+			batch.addApps = append(batch.addApps, d.App)
+			if d.Site != nil {
+				batch.addSites = append(batch.addSites, *d.Site)
+			}
+		}
+		for _, d := range plan.Update {
+			batch.updateApps = append(batch.updateApps, d.App)
+			if d.Site != nil {
+				batch.updateSites = append(batch.updateSites, *d.Site)
+			}
+		}
+		batch.removeKeys = append(batch.removeKeys, plan.RemoveKeys...)
 	}
 
 	if batch.empty() {
@@ -373,10 +439,22 @@ func containerSchemeForRefresh(c *ContainerSummary) string {
 	return "http"
 }
 
-// refreshBatch accumulates URL changes for one tick.
+// refreshBatch accumulates URL changes for one tick, plus the
+// auto-import reconcile output so both commit through the same atomic
+// SaveConfig + rollback in applyRefreshBatch.
 type refreshBatch struct {
 	appURLChanges  map[string]string // app name -> new URL
 	siteURLChanges map[string]string // gateway domain -> new BackendURL
+
+	// Auto-import reconcile output, folded into the same transaction as
+	// the URL refresh. addApps/updateApps carry their own URL (gateway
+	// apps carry the static domain); updates are matched by DockerKey.
+	// removeKeys drops apps AND any gateway site sharing that DockerKey.
+	addApps     []config.AppConfig
+	addSites    []config.GatewaySite
+	updateApps  []config.AppConfig
+	updateSites []config.GatewaySite
+	removeKeys  []string
 }
 
 func newRefreshBatch() *refreshBatch {
@@ -387,7 +465,17 @@ func newRefreshBatch() *refreshBatch {
 }
 
 func (b *refreshBatch) empty() bool {
-	return len(b.appURLChanges) == 0 && len(b.siteURLChanges) == 0
+	return len(b.appURLChanges) == 0 && len(b.siteURLChanges) == 0 &&
+		len(b.addApps) == 0 && len(b.addSites) == 0 &&
+		len(b.updateApps) == 0 && len(b.updateSites) == 0 &&
+		len(b.removeKeys) == 0
+}
+
+// reconcileChangesApps reports whether the auto-import plan touches any
+// app (added, updated, or removed). Used to fire the route-table
+// rebuild hook the same way an app URL change does.
+func (b *refreshBatch) reconcileChangesApps() bool {
+	return len(b.addApps) > 0 || len(b.updateApps) > 0 || len(b.removeKeys) > 0
 }
 
 func (b *refreshBatch) touchesGateway() bool {
@@ -432,10 +520,16 @@ func (p *Poller) applyRefreshBatch(batch *refreshBatch) {
 		}
 	}
 
+	// Fold the auto-import reconcile plan into the same in-memory
+	// transaction. Returns whether it added/updated/removed any gateway
+	// site so the Caddy reload below fires for auto-import too.
+	reconcileTouchedGateway := p.applyReconcile(batch)
+	gatewayTouched := batch.touchesGateway() || reconcileTouchedGateway
+
 	// Caddy reload, batched once for the whole tick. Only fires when
 	// the batch actually touches gateway sites - app-only changes
 	// don't need Caddy at all.
-	if batch.touchesGateway() && p.deps.Proxy != nil {
+	if gatewayTouched && p.deps.Proxy != nil {
 		newProxySites := proxy.ConfigGatewaySitesToProxy(p.deps.Config.Server.GatewaySites)
 		priorProxySites := proxy.ConfigGatewaySitesToProxy(priorSites)
 		err := p.deps.Proxy.ApplyGatewaySites(newProxySites, priorProxySites)
@@ -475,12 +569,12 @@ func (p *Poller) applyRefreshBatch(batch *refreshBatch) {
 		// == priorSites, so reading it for the second argument would
 		// pass priorSites twice and rollback would be a no-op.
 		var candidateProxy []proxy.GatewaySite
-		if batch.touchesGateway() && p.deps.Proxy != nil {
+		if gatewayTouched && p.deps.Proxy != nil {
 			candidateProxy = proxy.ConfigGatewaySitesToProxy(p.deps.Config.Server.GatewaySites)
 		}
 		p.deps.Config.Apps = priorApps
 		p.deps.Config.Server.GatewaySites = priorSites
-		if batch.touchesGateway() && p.deps.Proxy != nil {
+		if gatewayTouched && p.deps.Proxy != nil {
 			reassertErr := p.deps.Proxy.ApplyGatewaySites(
 				proxy.ConfigGatewaySitesToProxy(priorSites),
 				candidateProxy,
@@ -522,7 +616,7 @@ func (p *Poller) applyRefreshBatch(batch *refreshBatch) {
 	// silent IP shift would otherwise leave the proxy hitting the
 	// stale address. Skip when no apps changed (gateway-only batches
 	// don't touch the route table).
-	if len(batch.appURLChanges) > 0 && p.deps.OnConfigSaved != nil {
+	if (len(batch.appURLChanges) > 0 || batch.reconcileChangesApps()) && p.deps.OnConfigSaved != nil {
 		p.deps.OnConfigSaved()
 	}
 	for name, url := range batch.appURLChanges {
@@ -533,6 +627,92 @@ func (p *Poller) applyRefreshBatch(batch *refreshBatch) {
 		logging.Info("Docker gateway-site URL refreshed",
 			"source", "discovery", "domain", domain, "new_backend_url", url)
 	}
+	for i := range batch.addApps {
+		logging.Info("Docker container auto-imported",
+			"source", "audit", "app", batch.addApps[i].Name, "key", batch.addApps[i].DockerKey)
+	}
+	for i := range batch.updateApps {
+		logging.Info("Docker auto-imported app re-synced",
+			"source", "audit", "app", batch.updateApps[i].Name, "key", batch.updateApps[i].DockerKey)
+	}
+	for _, k := range batch.removeKeys {
+		logging.Info("Docker auto-imported entry removed (container vanished)",
+			"source", "audit", "key", k)
+	}
+}
+
+// applyReconcile folds the auto-import plan carried on the batch into
+// the live config. The caller (applyRefreshBatch) already holds the
+// write lock and has snapshotted priorApps/priorSites for rollback, so
+// this mutates p.deps.Config in place. Returns true when it added,
+// updated, or removed any gateway site, so the caller knows to reload
+// Caddy.
+func (p *Poller) applyReconcile(batch *refreshBatch) bool {
+	cfg := p.deps.Config
+	touchedGateway := false
+
+	// Removals first: drop vanished auto-imported apps and any gateway
+	// site sharing their DockerKey.
+	if len(batch.removeKeys) > 0 {
+		remove := make(map[string]bool, len(batch.removeKeys))
+		for _, k := range batch.removeKeys {
+			remove[k] = true
+		}
+		keptApps := cfg.Apps[:0]
+		for _, a := range cfg.Apps {
+			if a.DockerKey != "" && remove[a.DockerKey] {
+				continue
+			}
+			keptApps = append(keptApps, a)
+		}
+		cfg.Apps = keptApps
+		keptSites := cfg.Server.GatewaySites[:0]
+		for _, s := range cfg.Server.GatewaySites {
+			if s.DockerKey != "" && remove[s.DockerKey] {
+				touchedGateway = true
+				continue
+			}
+			keptSites = append(keptSites, s)
+		}
+		cfg.Server.GatewaySites = keptSites
+	}
+
+	// Updates: replace the existing app/site matched by DockerKey. A
+	// site with no current match is inserted (a label that newly added a
+	// gateway domain to an already-tracked app).
+	for i := range batch.updateApps {
+		na := batch.updateApps[i]
+		for j := range cfg.Apps {
+			if cfg.Apps[j].DockerKey == na.DockerKey {
+				cfg.Apps[j] = na
+				break
+			}
+		}
+	}
+	for i := range batch.updateSites {
+		ns := batch.updateSites[i]
+		found := false
+		for j := range cfg.Server.GatewaySites {
+			if cfg.Server.GatewaySites[j].DockerKey == ns.DockerKey {
+				cfg.Server.GatewaySites[j] = ns
+				found = true
+				break
+			}
+		}
+		if !found {
+			cfg.Server.GatewaySites = append(cfg.Server.GatewaySites, ns)
+		}
+		touchedGateway = true
+	}
+
+	// Additions.
+	cfg.Apps = append(cfg.Apps, batch.addApps...)
+	if len(batch.addSites) > 0 {
+		cfg.Server.GatewaySites = append(cfg.Server.GatewaySites, batch.addSites...)
+		touchedGateway = true
+	}
+
+	return touchedGateway
 }
 
 // save invokes the configured save function (typically Config.Save).

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -306,19 +306,19 @@ func (p *Poller) tick(ctx context.Context) {
 		scan := svc.Scan(ctx, dashboardDomain)
 		desired := make([]Desired, 0, len(scan.Suggestions))
 		for i := range scan.Suggestions {
-			desired = append(desired, BuildDesired(scan.Suggestions[i], endpoint))
+			desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
 		}
 		plan := Reconcile(autoImport, desired, currentApps)
-		for _, d := range plan.Add {
-			batch.addApps = append(batch.addApps, d.App)
-			if d.Site != nil {
-				batch.addSites = append(batch.addSites, *d.Site)
+		for i := range plan.Add {
+			batch.addApps = append(batch.addApps, plan.Add[i].App)
+			if plan.Add[i].Site != nil {
+				batch.addSites = append(batch.addSites, *plan.Add[i].Site)
 			}
 		}
-		for _, d := range plan.Update {
-			batch.updateApps = append(batch.updateApps, d.App)
-			if d.Site != nil {
-				batch.updateSites = append(batch.updateSites, *d.Site)
+		for i := range plan.Update {
+			batch.updateApps = append(batch.updateApps, plan.Update[i].App)
+			if plan.Update[i].Site != nil {
+				batch.updateSites = append(batch.updateSites, *plan.Update[i].Site)
 			}
 		}
 		batch.removeKeys = append(batch.removeKeys, plan.RemoveKeys...)
@@ -668,20 +668,20 @@ func (p *Poller) applyReconcile(batch *refreshBatch) bool {
 			remove[k] = true
 		}
 		keptApps := cfg.Apps[:0]
-		for _, a := range cfg.Apps {
-			if a.DockerKey != "" && remove[a.DockerKey] {
+		for i := range cfg.Apps {
+			if cfg.Apps[i].DockerKey != "" && remove[cfg.Apps[i].DockerKey] {
 				continue
 			}
-			keptApps = append(keptApps, a)
+			keptApps = append(keptApps, cfg.Apps[i])
 		}
 		cfg.Apps = keptApps
 		keptSites := cfg.Server.GatewaySites[:0]
-		for _, s := range cfg.Server.GatewaySites {
-			if s.DockerKey != "" && remove[s.DockerKey] {
+		for i := range cfg.Server.GatewaySites {
+			if cfg.Server.GatewaySites[i].DockerKey != "" && remove[cfg.Server.GatewaySites[i].DockerKey] {
 				touchedGateway = true
 				continue
 			}
-			keptSites = append(keptSites, s)
+			keptSites = append(keptSites, cfg.Server.GatewaySites[i])
 		}
 		cfg.Server.GatewaySites = keptSites
 	}

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -165,7 +165,10 @@ func (p *Poller) tick(ctx context.Context) {
 	enabled := p.deps.Config.Discovery.Docker.Enabled
 	endpoint := p.deps.Config.Discovery.Docker.Endpoint
 	hostIP := p.deps.Config.Discovery.Docker.HostIP
-	autoImport := p.deps.Config.Discovery.Docker.AutoImport
+	// Normalize defensively: the config PUT path normalizes before storing,
+	// but snapshotting through NormalizeAutoImport here guarantees the poller
+	// fails closed to off even if some future path ever stores a raw value.
+	autoImport := config.NormalizeAutoImport(p.deps.Config.Discovery.Docker.AutoImport)
 	dashboardDomain := p.deps.Config.Server.TLS.Domain
 	tracked := p.collectTracked()
 	// Snapshot the current apps for the reconcile diff while we hold the

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -296,6 +296,12 @@ func (p *Poller) tick(ctx context.Context) {
 	// trigger an Update, so that site-field change does not propagate
 	// until the container is removed and re-added. We intentionally do
 	// NOT gateway-site field-diff here; update mode re-syncs app fields.
+	//
+	// Overlap note: for a non-gateway auto app whose container IP changed
+	// with no label change, the URL-refresh pass above and Reconcile's
+	// Update below may both target the same app in one batch. Harmless:
+	// both resolve to the same final URL and commit in a single save, so
+	// this is not a double-write bug.
 	if autoImport != config.AutoImportOff {
 		scan := svc.Scan(ctx, dashboardDomain)
 		desired := make([]Desired, 0, len(scan.Suggestions))

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1361,6 +1361,113 @@ func TestTick_GatewayAppURLNotClobbered_SiteRefreshes(t *testing.T) {
 	}
 }
 
+// TestTick_GatewaySyncReconcile_AppURLStable_SiteRefreshes exercises the
+// gateway path with auto-import ACTIVE (sync mode), unlike
+// TestTick_GatewayAppURLNotClobbered_SiteRefreshes which leaves AutoImport
+// unset. A properly gateway-labeled container is already tracked as an
+// auto-imported gateway app + site. Across a tick where its IP changed, the
+// reconcile Update must NOT clobber the gateway app's static https://domain
+// URL (sameManagedFields sees the app URL unchanged) while the sibling
+// gateway Site's BackendURL still refreshes to the new container IP.
+func TestTick_GatewaySyncReconcile_AppURLStable_SiteRefreshes(t *testing.T) {
+	// gwSonarr resolves to 10.0.0.42 via container_ip; bump the IP so the
+	// site backend must refresh this tick.
+	c := gwSonarr()
+	c.NetworkSettings.Networks["media"] = ContainerNetwork{IPAddress: "10.0.0.77"}
+	set := []ContainerSummary{c}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportSync)
+	// Seed the already-imported gateway app + site (prior IP .42) so the tick
+	// hits the reconcile Update + the site-refresh path rather than an Add.
+	cfg.Apps = []config.AppConfig{{
+		Name: "Sonarr", URL: "https://sonarr.example.com", Proxy: false, Enabled: true,
+		Icon: config.AppIconConfig{Type: "dashboard", Name: "sonarr"},
+		// Color differs from the container's #00ff00 label so Reconcile emits
+		// an Update this tick: that proves the Update path re-syncs fields
+		// WITHOUT clobbering the static gateway URL.
+		Color:     "#111111",
+		DockerKey: "label:sonarr-auto", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "https://sonarr.example.com",
+		DockerAutoImported: true,
+	}}
+	cfg.Server.GatewaySites = []config.GatewaySite{{
+		Domain: "sonarr.example.com", BackendURL: "http://10.0.0.42:8989", TLS: "auto",
+		DockerKey: "label:sonarr-auto", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "http://10.0.0.42:8989",
+	}}
+
+	priorProxy := []proxy.GatewaySite{{Domain: "sonarr.example.com", BackendURL: "http://10.0.0.42:8989", TLS: "auto"}}
+	pxy := newProxyForBatchTest(priorProxy, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { return nil },
+	})
+
+	p.tick(context.Background())
+
+	app := findAppByKey(cfg, "label:sonarr-auto")
+	if app == nil || app.URL != "https://sonarr.example.com" {
+		t.Errorf("gateway app URL = %v, want stable https://sonarr.example.com (reconcile must not clobber)", app)
+	}
+	if app != nil && app.Color != "#00ff00" {
+		t.Errorf("gateway app color = %q, want re-synced to #00ff00 (Update path ran)", app.Color)
+	}
+	site := findSiteByKey(cfg, "label:sonarr-auto")
+	if site == nil || site.BackendURL != "http://10.0.0.77:8989" {
+		t.Errorf("gateway site backend = %v, want refreshed to .77", site)
+	}
+}
+
+// TestTick_AutoImportRollbackOnSaveFailure_Gateway is the gateway-path
+// sibling of TestTick_AutoImportRollbackOnSaveFailure. A sync-mode tick wants
+// to remove a vanished gateway app + its site, but SaveConfig fails. BOTH the
+// app and the gateway site must be restored to their prior state.
+func TestTick_AutoImportRollbackOnSaveFailure_Gateway(t *testing.T) {
+	// Empty daemon: the tracked gateway container has vanished, so sync mode
+	// plans a removal of both the app and its sibling site.
+	set := []ContainerSummary{}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportSync)
+	cfg.Apps = []config.AppConfig{{
+		Name: "Sonarr", URL: "https://sonarr.example.com", Proxy: false, Enabled: true,
+		DockerKey: "label:sonarr-auto", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "https://sonarr.example.com",
+		DockerAutoImported: true,
+	}}
+	cfg.Server.GatewaySites = []config.GatewaySite{{
+		Domain: "sonarr.example.com", BackendURL: "http://10.0.0.42:8989", TLS: "auto",
+		DockerKey: "label:sonarr-auto", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "http://10.0.0.42:8989",
+	}}
+
+	priorProxy := []proxy.GatewaySite{{Domain: "sonarr.example.com", BackendURL: "http://10.0.0.42:8989", TLS: "auto"}}
+	pxy := newProxyForBatchTest(priorProxy, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { return errors.New("synthetic save failure") },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:sonarr-auto") == nil {
+		t.Errorf("save failure must roll back the removal; app missing, apps=%+v", cfg.Apps)
+	}
+	site := findSiteByKey(cfg, "label:sonarr-auto")
+	if site == nil || site.BackendURL != "http://10.0.0.42:8989" {
+		t.Errorf("save failure must roll back the gateway site; got %v", site)
+	}
+}
+
 // gwSonarr is labeledSonarr plus a gateway-domain label, so Scan
 // suggests a gateway site and BuildDesired produces a Desired.Site.
 func gwSonarr() ContainerSummary {

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1040,3 +1040,482 @@ func TestPoller_Tick_StoppedContainerResolvesExitedNotMissing(t *testing.T) {
 		t.Fatalf("stopped tracked container state = %q, want \"exited\" (a running-only scan would yield \"missing\")", got.Status)
 	}
 }
+
+// --- Auto-import reconcile in the tick (Task 6) ---------------------------
+
+// mutableDaemonForPoller serves a container set the test can swap
+// between ticks (via the *set pointer), so update / vanish scenarios
+// can change what the daemon reports across reconcile passes.
+func mutableDaemonForPoller(t *testing.T, set *[]ContainerSummary) (string, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_ping", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/v1.41/containers/json", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(*set)
+	})
+	return fakeDockerOverUnix(t, mux)
+}
+
+// labeledSonarr is a running, media-network container carrying a stable
+// discovery id -> tracking key "label:sonarr-auto", URL via container_ip
+// -> http://10.0.0.42:8989.
+func labeledSonarr() ContainerSummary {
+	return ContainerSummary{
+		ID:     "auto-sonarr",
+		Names:  []string{"/sonarr"},
+		Image:  "linuxserver/sonarr",
+		Labels: map[string]string{LabelDiscoveryID: "sonarr-auto", LabelAppColor: "#00ff00"},
+		NetworkSettings: ContainerNetworks{
+			Networks: map[string]ContainerNetwork{"media": {IPAddress: "10.0.0.42"}},
+		},
+		Ports: []ContainerPort{{PrivatePort: 8989, Type: "tcp"}},
+	}
+}
+
+func findAppByKey(cfg *config.Config, key string) *config.AppConfig {
+	for i := range cfg.Apps {
+		if cfg.Apps[i].DockerKey == key {
+			return &cfg.Apps[i]
+		}
+	}
+	return nil
+}
+
+func findSiteByKey(cfg *config.Config, key string) *config.GatewaySite {
+	for i := range cfg.Server.GatewaySites {
+		if cfg.Server.GatewaySites[i].DockerKey == key {
+			return &cfg.Server.GatewaySites[i]
+		}
+	}
+	return nil
+}
+
+// autoImportCfg builds a Config whose discovery is enabled, points at
+// the given socket, and uses container_ip with a network filter set so
+// Scan bypasses self-detect gating.
+func autoImportCfg(socket string, mode config.AutoImportMode) (*config.Config, *config.DiscoveryDockerConfig) {
+	dockerCfg := &config.DiscoveryDockerConfig{
+		Enabled:         true,
+		Endpoint:        "unix://" + socket,
+		NetworkStrategy: "container_ip",
+		NetworkFilter:   "media",
+		AutoImport:      mode,
+	}
+	cfg := &config.Config{
+		Discovery: config.DiscoveryConfig{Docker: *dockerCfg},
+	}
+	return cfg, dockerCfg
+}
+
+func TestTick_AutoImportAdd(t *testing.T) {
+	set := []ContainerSummary{labeledSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	if svc.client == nil {
+		t.Fatalf("service has no client")
+	}
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	got := findAppByKey(cfg, "label:sonarr-auto")
+	if got == nil || !got.DockerAutoImported {
+		t.Fatalf("expected auto-imported Sonarr, apps=%+v", cfg.Apps)
+	}
+	if got.URL != "http://10.0.0.42:8989" {
+		t.Errorf("imported URL = %q, want container URL", got.URL)
+	}
+	if saveCalls != 1 {
+		t.Errorf("Save called %d times, want 1", saveCalls)
+	}
+}
+
+func TestTick_AutoImportOff_DoesNotImport(t *testing.T) {
+	set := []ContainerSummary{labeledSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportOff)
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:sonarr-auto") != nil {
+		t.Errorf("off mode must not import; apps=%+v", cfg.Apps)
+	}
+	if saveCalls != 0 {
+		t.Errorf("Save called %d times, want 0 in off mode", saveCalls)
+	}
+}
+
+func TestTick_AutoImportUpdate_ResyncsChangedFieldOnly(t *testing.T) {
+	set := []ContainerSummary{labeledSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	// First tick (add) imports the app with color #00ff00.
+	p.tick(context.Background())
+	app := findAppByKey(cfg, "label:sonarr-auto")
+	if app == nil || app.Color != "#00ff00" {
+		t.Fatalf("add import failed, app=%+v", app)
+	}
+	if saveCalls != 1 {
+		t.Fatalf("save after add = %d, want 1", saveCalls)
+	}
+
+	// Switch to update mode, no container change -> no update.
+	cfg.Discovery.Docker.AutoImport = config.AutoImportUpdate
+	p.tick(context.Background())
+	if saveCalls != 1 {
+		t.Errorf("unchanged update tick saved (%d); want no write", saveCalls)
+	}
+
+	// Change a label-controlled field -> update re-syncs it.
+	set[0].Labels[LabelAppColor] = "#ff0000"
+	p.tick(context.Background())
+	app = findAppByKey(cfg, "label:sonarr-auto")
+	if app == nil || app.Color != "#ff0000" {
+		t.Fatalf("update did not re-sync color, app=%+v", app)
+	}
+	if saveCalls != 2 {
+		t.Errorf("save after update = %d, want 2", saveCalls)
+	}
+}
+
+func TestTick_AutoImportSyncRemovesVanished(t *testing.T) {
+	// No containers reported; an auto app + its gateway site exist.
+	set := []ContainerSummary{}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportSync)
+	cfg.Apps = []config.AppConfig{{
+		Name: "Sonarr", URL: "https://sonarr.example.com", Proxy: false,
+		DockerKey: "label:gone", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "https://sonarr.example.com",
+		DockerAutoImported: true,
+	}}
+	cfg.Server.GatewaySites = []config.GatewaySite{{
+		Domain: "sonarr.example.com", BackendURL: "http://10.0.0.1:8989", TLS: "auto",
+		DockerKey: "label:gone", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "http://10.0.0.1:8989",
+	}}
+
+	priorProxy := []proxy.GatewaySite{{Domain: "sonarr.example.com", BackendURL: "http://10.0.0.1:8989", TLS: "auto"}}
+	pxy := newProxyForBatchTest(priorProxy, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:gone") != nil {
+		t.Errorf("sync mode should remove vanished auto app; apps=%+v", cfg.Apps)
+	}
+	if findSiteByKey(cfg, "label:gone") != nil {
+		t.Errorf("sync mode should remove the vanished gateway site; sites=%+v", cfg.Server.GatewaySites)
+	}
+	if saveCalls != 1 {
+		t.Errorf("Save called %d times, want 1", saveCalls)
+	}
+}
+
+func TestTick_AutoImportAddMode_DoesNotRemoveVanished(t *testing.T) {
+	set := []ContainerSummary{}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	cfg.Apps = []config.AppConfig{{
+		Name: "Sonarr", URL: "http://10.0.0.1:8989",
+		DockerKey: "label:gone", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "http://10.0.0.1:8989",
+		DockerAutoImported: true,
+	}}
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:gone") == nil {
+		t.Errorf("add mode must NOT remove a vanished auto app")
+	}
+}
+
+func TestTick_AutoImportLeavesManual(t *testing.T) {
+	// Manual app (tracked but not auto-imported), container gone, sync mode.
+	set := []ContainerSummary{}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportSync)
+	cfg.Apps = []config.AppConfig{{
+		Name: "Manual", URL: "http://10.0.0.1:8989",
+		DockerKey: "label:manual", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerManagedURL: "http://10.0.0.1:8989",
+		DockerAutoImported: false,
+	}}
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:manual") == nil {
+		t.Errorf("manual app must never be removed by sync; apps=%+v", cfg.Apps)
+	}
+	if saveCalls != 0 {
+		t.Errorf("nothing should change for a manual app; saves=%d", saveCalls)
+	}
+}
+
+func TestTick_GatewayAppURLNotClobbered_SiteRefreshes(t *testing.T) {
+	// A gateway-routed tracked app: App.URL is the static domain, the
+	// sibling tracked site carries the container backend. The refresh
+	// pass must leave the app URL alone while updating the site backend.
+	containers := []ContainerSummary{{
+		ID:     "gw1",
+		Names:  []string{"/sonarr"},
+		Image:  "linuxserver/sonarr",
+		Labels: map[string]string{LabelDiscoveryID: "gw-sonarr"},
+		NetworkSettings: ContainerNetworks{
+			Networks: map[string]ContainerNetwork{"media": {IPAddress: "10.0.0.99"}},
+		},
+		Ports: []ContainerPort{{PrivatePort: 8989, Type: "tcp"}},
+	}}
+	socket, cleanup := fakeDaemonForPoller(t, containers)
+	defer cleanup()
+
+	dockerCfg := &config.DiscoveryDockerConfig{
+		Enabled: true, Endpoint: "unix://" + socket, NetworkStrategy: "container_ip",
+	}
+	cfg := &config.Config{
+		Discovery: config.DiscoveryConfig{Docker: *dockerCfg},
+		Apps: []config.AppConfig{{
+			Name: "Sonarr", URL: "https://sonarr.example.com", Proxy: false,
+			DockerKey: "label:gw-sonarr", DockerEndpoint: "unix://" + socket,
+			DockerStrategy: "container_ip", DockerManagedURL: "https://sonarr.example.com",
+			DockerAutoImported: true,
+		}},
+		Server: config.ServerConfig{GatewaySites: []config.GatewaySite{{
+			Domain: "sonarr.example.com", BackendURL: "http://10.0.0.1:8989", TLS: "auto",
+			DockerKey: "label:gw-sonarr", DockerEndpoint: "unix://" + socket,
+			DockerStrategy: "container_ip", DockerManagedURL: "http://10.0.0.1:8989",
+		}}},
+	}
+
+	priorProxy := []proxy.GatewaySite{{Domain: "sonarr.example.com", BackendURL: "http://10.0.0.1:8989", TLS: "auto"}}
+	pxy := newProxyForBatchTest(priorProxy, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { return nil },
+	})
+
+	p.tick(context.Background())
+
+	if cfg.Apps[0].URL != "https://sonarr.example.com" {
+		t.Errorf("gateway app URL clobbered to %q; must stay the domain", cfg.Apps[0].URL)
+	}
+	if cfg.Server.GatewaySites[0].BackendURL != "http://10.0.0.99:8989" {
+		t.Errorf("gateway site backend = %q, want refreshed to .99", cfg.Server.GatewaySites[0].BackendURL)
+	}
+}
+
+// gwSonarr is labeledSonarr plus a gateway-domain label, so Scan
+// suggests a gateway site and BuildDesired produces a Desired.Site.
+func gwSonarr() ContainerSummary {
+	c := labeledSonarr()
+	c.Labels[LabelAppGatewayDomain] = "sonarr.example.com"
+	c.Labels[LabelGatewayTLS] = "auto"
+	return c
+}
+
+func TestTick_AutoImportAdd_GatewaySite(t *testing.T) {
+	set := []ContainerSummary{gwSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	pxy := newProxyForBatchTest([]proxy.GatewaySite{}, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	app := findAppByKey(cfg, "label:sonarr-auto")
+	if app == nil || app.URL != "https://sonarr.example.com" || app.Proxy {
+		t.Fatalf("gateway app not imported correctly: %+v", app)
+	}
+	site := findSiteByKey(cfg, "label:sonarr-auto")
+	if site == nil || site.Domain != "sonarr.example.com" || site.BackendURL != "http://10.0.0.42:8989" {
+		t.Fatalf("gateway site not imported correctly: %+v", site)
+	}
+	if saveCalls != 1 {
+		t.Errorf("Save called %d times, want 1", saveCalls)
+	}
+
+	// Update mode + a changed app field re-syncs the app AND replaces the
+	// existing gateway site (updateSites found-replace path).
+	cfg.Discovery.Docker.AutoImport = config.AutoImportUpdate
+	set[0].Labels[LabelAppColor] = "#abcdef"
+	p.tick(context.Background())
+	app = findAppByKey(cfg, "label:sonarr-auto")
+	if app == nil || app.Color != "#abcdef" {
+		t.Fatalf("gateway app update did not re-sync color: %+v", app)
+	}
+	if s := findSiteByKey(cfg, "label:sonarr-auto"); s == nil || s.Domain != "sonarr.example.com" {
+		t.Fatalf("gateway site lost on update: %+v", s)
+	}
+}
+
+// TestTick_AutoImportUpdate_InsertsGatewaySiteWhenLabelAdded covers the
+// updateSites not-found insert path: a direct app is auto-imported, then
+// a gateway-domain label is added to the container. Update mode then
+// changes App.URL (direct -> gateway domain) so Reconcile emits an
+// Update whose Desired.Site has no current match and must be inserted.
+func TestTick_AutoImportUpdate_InsertsGatewaySiteWhenLabelAdded(t *testing.T) {
+	set := []ContainerSummary{labeledSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	pxy := newProxyForBatchTest([]proxy.GatewaySite{}, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { return nil },
+	})
+
+	p.tick(context.Background()) // direct import, no site
+	if findSiteByKey(cfg, "label:sonarr-auto") != nil {
+		t.Fatalf("direct import should not create a gateway site")
+	}
+
+	cfg.Discovery.Docker.AutoImport = config.AutoImportUpdate
+	set[0].Labels[LabelAppGatewayDomain] = "sonarr.example.com"
+	set[0].Labels[LabelGatewayTLS] = "auto"
+	p.tick(context.Background())
+
+	app := findAppByKey(cfg, "label:sonarr-auto")
+	if app == nil || app.URL != "https://sonarr.example.com" {
+		t.Fatalf("app URL should switch to the gateway domain: %+v", app)
+	}
+	site := findSiteByKey(cfg, "label:sonarr-auto")
+	if site == nil || site.BackendURL != "http://10.0.0.42:8989" {
+		t.Fatalf("gateway site should be inserted on the label add: %+v", site)
+	}
+}
+
+func TestTick_AutoImportRollbackOnSaveFailure(t *testing.T) {
+	set := []ContainerSummary{labeledSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc,
+		OnSave: func() error { return errors.New("synthetic save failure") },
+	})
+
+	p.tick(context.Background())
+
+	if len(cfg.Apps) != 0 {
+		t.Errorf("save failure must roll back the import; apps=%+v", cfg.Apps)
+	}
+}
+
+func TestTick_AutoImportSkipsSelfAndNetworkFiltered(t *testing.T) {
+	// Three containers: a self (muximux) container, an off-network
+	// container, and the real sonarr on media. Only sonarr imports.
+	set := []ContainerSummary{
+		{
+			ID: "self", Names: []string{"/muximux"}, Image: "ghcr.io/mescon/muximux:latest",
+			Labels: map[string]string{LabelDiscoveryID: "self-id"},
+			NetworkSettings: ContainerNetworks{
+				Networks: map[string]ContainerNetwork{"media": {IPAddress: "10.0.0.10"}},
+			},
+			Ports: []ContainerPort{{PrivatePort: 8080, Type: "tcp"}},
+		},
+		{
+			ID: "other", Names: []string{"/grafana"}, Image: "grafana/grafana",
+			Labels: map[string]string{LabelDiscoveryID: "grafana-id"},
+			NetworkSettings: ContainerNetworks{
+				Networks: map[string]ContainerNetwork{"isolated": {IPAddress: "10.9.9.9"}},
+			},
+			Ports: []ContainerPort{{PrivatePort: 3000, Type: "tcp"}},
+		},
+		labeledSonarr(),
+	}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc,
+		OnSave: func() error { return nil },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:self-id") != nil {
+		t.Errorf("self container must not be imported")
+	}
+	if findAppByKey(cfg, "label:grafana-id") != nil {
+		t.Errorf("off-network container must not be imported")
+	}
+	if findAppByKey(cfg, "label:sonarr-auto") == nil {
+		t.Errorf("media-network sonarr should import; apps=%+v", cfg.Apps)
+	}
+}

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -592,6 +592,13 @@ func applyDockerTrackingPreservation(updated *config.AppConfig, existing *config
 	// stored URL so a re-link or no-op save doesn't accidentally
 	// stale the baseline Load() compares against.
 	updated.DockerManagedURL = updated.URL
+	// A non-URL edit keeps the app auto-managed: ClientAppConfig has no
+	// docker_auto field, so updated.DockerAutoImported arrives false on a
+	// normal UI save. Preserve the marker to mirror the YAML path, where
+	// Load() only detaches on a URL change. Managed fields are re-synced
+	// from labels under update/sync; change the URL or remove the
+	// container labels to detach.
+	updated.DockerAutoImported = existing.DockerAutoImported
 	return ""
 }
 

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -576,6 +576,7 @@ func applyDockerTrackingPreservation(updated *config.AppConfig, existing *config
 		updated.DockerEndpoint = existing.DockerEndpoint
 		updated.DockerStrategy = existing.DockerStrategy
 		updated.DockerManagedURL = existing.DockerManagedURL
+		updated.DockerAutoImported = existing.DockerAutoImported
 		return ""
 	}
 	if existing.DockerKey != "" && existing.URL != "" && updated.URL != existing.URL {
@@ -584,6 +585,7 @@ func applyDockerTrackingPreservation(updated *config.AppConfig, existing *config
 		updated.DockerEndpoint = ""
 		updated.DockerStrategy = ""
 		updated.DockerManagedURL = ""
+		updated.DockerAutoImported = false
 		return reason
 	}
 	// Tracking stays; keep DockerManagedURL in sync with the

--- a/internal/handlers/api_test.go
+++ b/internal/handlers/api_test.go
@@ -1826,6 +1826,53 @@ func TestApplyDockerTrackingPreservation_RetainsTrackingOnNonURLEdits(t *testing
 	}
 }
 
+// TestApplyDockerTrackingPreservation_DockerAutoImportedMarker pins the
+// provenance marker's lifecycle across a config save. The marker must be
+// preserved alongside the other tracking fields on an empty-payload PUT
+// (DockerKey == ""), and cleared in lockstep with the tracking fields when
+// a URL change auto-detaches the app. This keeps the save path consistent
+// with the detach Load() already performs.
+func TestApplyDockerTrackingPreservation_DockerAutoImportedMarker(t *testing.T) {
+	t.Run("preserved on empty-payload PUT", func(t *testing.T) {
+		existing := config.AppConfig{
+			Name: "App1", URL: "http://10.0.0.1:80",
+			DockerKey: "label:foo", DockerEndpoint: "unix:///x.sock", DockerStrategy: "container_ip",
+			DockerAutoImported: true,
+		}
+		updated := config.AppConfig{
+			Name: "App1", URL: "http://10.0.0.1:80",
+			// empty DockerKey signals a payload without tracking fields
+		}
+		reason := applyDockerTrackingPreservation(&updated, &existing)
+		if reason != "" {
+			t.Errorf("empty-payload PUT unexpectedly detached with reason %q", reason)
+		}
+		if !updated.DockerAutoImported {
+			t.Errorf("DockerAutoImported not preserved from existing: %+v", updated)
+		}
+	})
+
+	t.Run("cleared on URL-change auto-detach", func(t *testing.T) {
+		existing := config.AppConfig{
+			Name: "App1", URL: "http://10.0.0.1:80",
+			DockerKey: "label:foo", DockerEndpoint: "unix:///x.sock", DockerStrategy: "container_ip",
+			DockerAutoImported: true,
+		}
+		updated := config.AppConfig{
+			Name: "App1", URL: "http://manual:9999", // URL changed -> manual control
+			DockerKey: "label:foo", DockerEndpoint: "unix:///x.sock", DockerStrategy: "container_ip",
+			DockerAutoImported: true,
+		}
+		reason := applyDockerTrackingPreservation(&updated, &existing)
+		if reason == "" {
+			t.Fatal("URL change on a tracked app should have detached")
+		}
+		if updated.DockerAutoImported {
+			t.Errorf("DockerAutoImported not cleared by auto-detach: %+v", updated)
+		}
+	})
+}
+
 func TestCreateAppMissingName(t *testing.T) {
 	cfg := createTestConfig()
 	handler := NewAPIHandler(cfg, "", &sync.RWMutex{})

--- a/internal/handlers/api_test.go
+++ b/internal/handlers/api_test.go
@@ -1871,6 +1871,28 @@ func TestApplyDockerTrackingPreservation_DockerAutoImportedMarker(t *testing.T) 
 			t.Errorf("DockerAutoImported not cleared by auto-detach: %+v", updated)
 		}
 	})
+
+	t.Run("preserved on non-URL UI save", func(t *testing.T) {
+		existing := config.AppConfig{
+			Name: "App1", URL: "http://10.0.0.1:80",
+			DockerKey: "label:foo", DockerEndpoint: "unix:///x.sock", DockerStrategy: "container_ip",
+			DockerAutoImported: true,
+		}
+		updated := config.AppConfig{
+			Name: "App1", URL: "http://10.0.0.1:80", // same URL
+			DockerKey: "label:foo", DockerEndpoint: "unix:///x.sock", DockerStrategy: "container_ip",
+			// ClientAppConfig has no docker_auto field, so the wire form
+			// arrives with DockerAutoImported == false on a normal UI save.
+			DockerAutoImported: false,
+		}
+		reason := applyDockerTrackingPreservation(&updated, &existing)
+		if reason != "" {
+			t.Errorf("non-URL save unexpectedly detached with reason %q", reason)
+		}
+		if !updated.DockerAutoImported {
+			t.Errorf("DockerAutoImported not preserved on non-URL save: %+v", updated)
+		}
+	})
 }
 
 func TestCreateAppMissingName(t *testing.T) {

--- a/internal/handlers/discovery.go
+++ b/internal/handlers/discovery.go
@@ -191,6 +191,13 @@ func (h *DiscoveryHandler) UpdateDockerConfig(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Normalize the auto-import mode the SAME way config.Load does, failing
+	// closed to off for an unknown / empty value. The poller shares this live
+	// *config.Config and treats only the literal "off" as off, so a raw value
+	// stored here would fall through Reconcile and silently auto-import until
+	// the next restart re-normalized it on load.
+	newCfg.AutoImport = config.NormalizeAutoImport(newCfg.AutoImport)
+
 	// Snapshot, mutate, save, rollback on failure - same shape as the
 	// auth-config update path. Persist BEFORE rebuilding the service so
 	// a save failure leaves the running service untouched.

--- a/internal/handlers/discovery_test.go
+++ b/internal/handlers/discovery_test.go
@@ -311,6 +311,42 @@ func TestUpdateDockerConfig_RejectsUnknownLifecycleMinRole(t *testing.T) {
 	}
 }
 
+func TestUpdateDockerConfig_NormalizesGarbageAutoImportToOff(t *testing.T) {
+	// A PUT carrying an unknown auto_import value must NOT land unnormalized
+	// in the live config: the poller treats only the literal "off" as off, so
+	// a garbage value would fall through Reconcile and silently auto-import.
+	// The handler must normalize the mode the same way config.Load does,
+	// failing closed to off.
+	h, cfg, configPath := newTestDiscoveryHandler(t, &config.DiscoveryDockerConfig{Enabled: false})
+
+	body := []byte(`{
+		"enabled": true,
+		"endpoint": "unix:///tmp/x.sock",
+		"network_strategy": "container_ip",
+		"auto_import": "definitely-not-a-mode"
+	}`)
+	req := adminCtxRequest(http.MethodPut, "/api/discovery/docker/config")
+	req.Body = httpBody(body)
+	w := httptest.NewRecorder()
+	h.UpdateDockerConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q", w.Code, w.Body.String())
+	}
+
+	if cfg.Discovery.Docker.AutoImport != config.AutoImportOff {
+		t.Errorf("in-memory AutoImport = %q, want off (garbage must normalize)", cfg.Discovery.Docker.AutoImport)
+	}
+	// And the on-disk copy must agree so a restart can't resurrect the
+	// garbage value either.
+	persisted, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if persisted.Discovery.Docker.AutoImport != config.AutoImportOff {
+		t.Errorf("persisted AutoImport = %q, want off", persisted.Discovery.Docker.AutoImport)
+	}
+}
+
 func TestScanDocker_NilService(t *testing.T) {
 	h := NewDiscoveryHandler(nil, &config.Config{}, "", &sync.RWMutex{}, nil)
 	req := adminCtxRequest(http.MethodGet, "/api/discovery/docker/scan")


### PR DESCRIPTION
## Summary

Adds opt-in **automatic import of `muximux.*`-labeled Docker containers** into the dashboard config, driven by the existing discovery poller. Today a labeled container only appears as a manual-import suggestion; this lets operators run a hands-off GitOps flow where declaring an app (and optionally its gateway routing) in compose labels makes it appear automatically.

Targets **3.2.0** (new feature). Off by default; no behavior change for existing installs.

## Modes

New `discovery.docker.auto_import` (and env override `MUXIMUX_DISCOVERY_AUTO_IMPORT`):

| Mode | New container | Label change | Container gone |
|------|---------------|--------------|----------------|
| `off` (default) | suggestion only (today's behavior) | -- | -- |
| `add` | auto-import once | ignored | left in place |
| `update` | auto-import | re-sync app fields | left in place |
| `sync` | auto-import | re-sync app fields | remove app (+ gateway site) |

## Design and safety

- **Provenance marker** (`DockerAutoImported`): auto-import only ever updates or removes apps it created. A manually-imported app is never touched, even in `sync`. Verified symmetric across `config.Load` detach and `applyDockerTrackingPreservation` (both save branches).
- **Edit-wins**: changing an auto-imported app's URL (or removing the container's labels) detaches it from auto-management; other managed-field edits re-sync from labels under `update`/`sync` and stick under `add`. UI and YAML behave identically.
- **Atomicity**: the reconcile rides the existing refresh batch and commits through one `SaveConfig` with the existing rollback, restoring both apps and gateway sites on failure.
- **Gateway parity**: an auto-imported gateway app/site is field-identical to a manual import (`App.URL=https://domain`, `Proxy=false`, `Site.BackendURL=container`); gateway-routed apps are protected from URL-clobber in the refresh pass.
- **Off by default, three-layer enforced**: `NormalizeAutoImport` fails closed on unknown/empty values (load, env, and the config PUT path all normalize), the tick early-returns in `off`, and `Reconcile` short-circuits in `off`. Enabling a non-off mode imports every labeled container with no review step (including public gateway subdomains) -- documented prominently as an operator-controlled trust decision.

## Known limitation (documented; fast-follow)

In `update`/`sync`, re-sync detects app-field changes. `gateway.domain`/`gateway.tls` change the app URL and propagate, but a change to gateway-only labels (`require_auth`, `min_role`, `streaming`, `strip_frame_blockers`, `forwarded_headers`) on an already-imported container does not propagate via update until the container is re-added. Initial import honors them correctly. A follow-up will add gateway-site field diffing.

## Changes

- `internal/config`: `auto_import` mode + validation, `DockerAutoImported` marker, `MUXIMUX_DISCOVERY_AUTO_IMPORT` override.
- `internal/discovery`: `BuildDesired` (suggestion -> app/site), `Reconcile` (per-mode diff), poller-tick integration + startup reconcile.
- `internal/handlers`: marker preservation on config save; mode normalization on PUT.
- Docs: wiki Automatic Import section + security note; compose example; CHANGELOG.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `golangci-lint run ./...`, `gofmt` all clean
- [x] Table-driven coverage of every mode + reconcile branch, provenance (manual untouched), atomic rollback (apps + gateway sites), gateway URL-stability, off-by-default, env/PUT normalization
- [ ] CI + SonarCloud new-code coverage gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional automatic import for Docker containers labeled for discovery, with configurable modes for adding, updating, syncing, or leaving them off.
  * Added support for an environment variable override for this setting.

* **Bug Fixes**
  * Normalized invalid auto-import values to a safe default.
  * Preserved auto-import tracking when saving apps, and detached apps from automation when edited manually.

* **Documentation**
  * Expanded changelog, compose comments, and discovery docs with usage, modes, and important behavior notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->