### PR TITLE
docs: audit and update all docs to reflect 3.2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,9 @@ services:
 #
 # Any service you label with muximux.* keys appears in Muximux's
 # Discover modal (Settings > Discovery) pre-filled for one-click
-# import. The example below shows the full label set; you can
+# import -- or, with MUXIMUX_DISCOVERY_AUTO_IMPORT /
+# discovery.docker.auto_import enabled, is imported automatically
+# with no click. The example below shows the full label set; you can
 # omit the ones you don't need. See the docker-discovery wiki
 # page for the full reference and per-platform setup.
 #
@@ -165,5 +167,5 @@ services:
 #       context: .
 #       dockerfile: Dockerfile
 #       args:
-#         VERSION: "3.1.0"
+#         VERSION: "3.2.0"
 #     ...

--- a/docs/wiki/api.md
+++ b/docs/wiki/api.md
@@ -22,6 +22,7 @@ When authentication is enabled, most endpoints require a valid session cookie or
 | `/api/auth/users/{username}` | PUT | Admin | Update user role/email/display name |
 | `/api/auth/users/{username}` | DELETE | Admin | Delete a user |
 | `/api/auth/method` | PUT | Admin | Switch authentication method |
+| `/api/auth/api-key` | GET | Admin | Report whether an instance API key is configured (never returns the key) |
 | `/api/auth/api-key` | POST | Admin | Generate or rotate the instance API key |
 | `/api/auth/api-key` | DELETE | Admin | Clear the instance API key |
 | `/api/auth/setup` | POST | No (but requires `X-Setup-Token`) | Initial setup (onboarding wizard). See [Authentication > First-Run Setup](authentication.md#first-run-setup) for the token. |

--- a/docs/wiki/api.md
+++ b/docs/wiki/api.md
@@ -22,6 +22,8 @@ When authentication is enabled, most endpoints require a valid session cookie or
 | `/api/auth/users/{username}` | PUT | Admin | Update user role/email/display name |
 | `/api/auth/users/{username}` | DELETE | Admin | Delete a user |
 | `/api/auth/method` | PUT | Admin | Switch authentication method |
+| `/api/auth/api-key` | POST | Admin | Generate or rotate the instance API key |
+| `/api/auth/api-key` | DELETE | Admin | Clear the instance API key |
 | `/api/auth/setup` | POST | No (but requires `X-Setup-Token`) | Initial setup (onboarding wizard). See [Authentication > First-Run Setup](authentication.md#first-run-setup) for the token. |
 | `/api/auth/oidc/login` | GET | No | Redirect to OIDC provider |
 | `/api/auth/oidc/callback` | GET | No | OIDC callback handler |
@@ -209,6 +211,8 @@ Returns a JSON snapshot with `language`, `theme` (`family`, `variant`, `id`, `is
 | `/api/app/{name}` | GET | Any | Get app by name |
 | `/api/app/{name}` | PUT | Admin | Update app |
 | `/api/app/{name}` | DELETE | Admin | Delete app |
+| `/api/app-action/{name}` | POST | Per-app role gate | Fire the app's configured http_action HTTP request |
+| `/api/app-docker/{name}/{start\|stop\|restart}` | POST | Role-gated | Control a Docker-tracked container (requires lifecycle_enabled + :rw socket) |
 
 **Create app request:**
 ```json
@@ -237,6 +241,26 @@ POST /api/apps
 | `/api/group/{name}` | GET | Any | Get group by name |
 | `/api/group/{name}` | PUT | Admin | Update group |
 | `/api/group/{name}` | DELETE | Admin | Delete group |
+
+---
+
+## Discovery
+
+| Endpoint | Method | Role | Description |
+|----------|--------|------|-------------|
+| `/api/discovery/docker/status` | GET | Admin | Docker daemon reachability + discovery config |
+| `/api/discovery/docker/networks` | GET | Admin | List Docker networks for URL resolution |
+| `/api/discovery/docker/config` | PUT | Admin | Update discovery config (incl. auto_import mode, lifecycle_enabled) |
+| `/api/discovery/docker/test` | POST | Admin | Test a discovery config without saving |
+| `/api/discovery/docker/scan` | GET | Admin | Scan the daemon, return importable containers |
+| `/api/discovery/docker/import` | POST | Admin | Import selected containers as apps |
+| `/api/discovery/docker/tracked` | GET | Admin | List apps currently tracked from Docker |
+| `/api/discovery/docker/track/{name}` | DELETE | Admin | Detach an app from Docker tracking |
+| `/api/discovery/docker/relink/probe` | POST | Admin | Probe a container to re-link a detached app |
+| `/api/discovery/docker/relink/confirm` | POST | Admin | Confirm a re-link |
+| `/api/discovery/docker-state` | GET | Any | Current container-state map for tracked apps |
+
+Auto-import is opt-in via `discovery.docker.auto_import` (`off`, `add`, `update`, or `sync`). The discovery configuration is also part of the full configuration object, so it can be set via `PUT /api/config` as well as `PUT /api/discovery/docker/config`.
 
 ---
 
@@ -337,7 +361,7 @@ The server downloads the image, validates the content type and size (2MB limit),
 |-----------|------|---------|-------------|
 | `limit` | int | 200 | Maximum number of entries to return |
 | `level` | string | | Filter by log level (`debug`, `info`, `warn`, `error`) |
-| `source` | string | | Filter by source tag (`server`, `proxy`, `health`, `auth`, `websocket`, `caddy`, `config`, `icons`, `themes`) |
+| `source` | string | | Filter by source tag (`http`, `audit`, `server`, `auth`, `health`, `proxy`, `websocket`, `caddy`, `config`, `icons`, `themes`, `discovery`, `gateway`, `system`) |
 
 **Example:**
 ```
@@ -391,10 +415,10 @@ Logs are stored in a 1000-entry ring buffer. When the buffer is full, the oldest
 **Update check response:**
 ```json
 {
-  "current_version": "3.0.0",
-  "latest_version": "3.1.0",
+  "current_version": "3.1.1",
+  "latest_version": "3.2.0",
   "update_available": true,
-  "release_url": "https://github.com/mescon/Muximux/releases/tag/v3.1.0",
+  "release_url": "https://github.com/mescon/Muximux/releases/tag/v3.2.0",
   "changelog": "..."
 }
 ```
@@ -416,6 +440,22 @@ Logs are stored in a 1000-entry ring buffer. When the buffer is full, the oldest
   "domain": "muximux.example.com"
 }
 ```
+
+---
+
+## Gateway
+
+The declarative `server.gateway_sites:` model is the current gateway path (the legacy Caddyfile was removed in 3.1.0).
+
+| Endpoint | Method | Role | Description |
+|----------|--------|------|-------------|
+| `/api/gateway/sites` | GET | Admin | List configured gateway sites |
+| `/api/gateway/sites` | POST | Admin | Create a gateway site |
+| `/api/gateway/sites/{domain}` | PUT | Admin | Update a gateway site |
+| `/api/gateway/sites/{domain}` | DELETE | Admin | Delete a gateway site |
+| `/api/gateway/validate` | POST | Admin | Validate a gateway site config without saving |
+
+`/api/auth/forward` is the internal forward-auth verify endpoint used by the gateway to gate access. It is not meant to be called directly from a browser (a direct hit returns `400`).
 
 ---
 

--- a/docs/wiki/apps.md
+++ b/docs/wiki/apps.md
@@ -54,7 +54,7 @@ apps:
 
 ### Adding apps from Docker
 
-If your apps run as Docker containers, **Apps tab → Discover from Docker** scans your daemon and proposes ready-to-import entries (name, icon, port pre-filled for known images). Imported apps are auto-managed: Muximux refreshes their URL whenever the container's IP changes. See [Docker Discovery](docker-discovery.md) for the full flow.
+If your apps run as Docker containers, **Apps tab → Discover from Docker** scans your daemon and proposes ready-to-import entries (name, icon, port pre-filled for known images). Imported apps are auto-managed: Muximux refreshes their URL whenever the container's IP changes. Prefer GitOps? Turn on `discovery.docker.auto_import` and labeled containers are imported automatically -- no modal, no click. See [Docker Discovery](docker-discovery.md) for the full flow.
 
 ---
 

--- a/docs/wiki/configuration.md
+++ b/docs/wiki/configuration.md
@@ -165,6 +165,11 @@ discovery:
     network_filter: ""                           # scope scans to one docker network when set
     host_ip: ""                                  # required by host_port strategy
     refresh_interval: 60s                        # poller cadence
+    auto_import: off                             # off (default) | add | update | sync; auto-import muximux.*-labeled containers
+    lifecycle_enabled: false                     # allow start/stop/restart of tracked containers (requires :rw socket mount)
+    lifecycle_min_role: admin                    # min role for lifecycle controls
+    lifecycle_allowed_groups: []                 # additionally require group membership
+    health_badge_placement: overview             # overview | overview_and_nav | off
     tls:                                         # only needed for tcp:// with mTLS
       enabled: false
       ca_cert: ""                                # CA bundle that signed the daemon cert
@@ -204,7 +209,7 @@ apps:
     order: 1
     enabled: true
     default: true
-    open_mode: iframe          # iframe, new_tab, new_window, redirect
+    open_mode: iframe          # iframe, new_tab, new_window, redirect, http_action
     proxy: false
     proxy_skip_tls_verify: true  # Skip TLS certificate verification (default: true)
     proxy_headers:               # Custom headers sent to the backend

--- a/docs/wiki/docker-discovery.md
+++ b/docs/wiki/docker-discovery.md
@@ -9,6 +9,7 @@ Connect Muximux to a Docker daemon and it can enumerate running containers, prop
 - **Scan**: lists running containers and proposes a name, icon, URL, port, and group for each, with confidence ratings (high / medium / low).
 - **Import**: one-click adds the chosen containers as apps in the menu, gateway subdomains, or both. Each row picks a routing mode: Direct URL, internal Proxy, or Gateway domain.
 - **Refresh**: a background poller (default 60s) re-resolves each tracked container against the daemon and rewrites the saved URL if the container's IP changes. Caddy reloads once per tick when gateway-site URLs change.
+- **Auto-import** (optional): with `discovery.docker.auto_import` set to `add`/`update`/`sync`, Muximux imports `muximux.*`-labeled containers with no modal and no click, and keeps them in step with the labels. Off by default. See [Automatic Import](#automatic-import).
 - **Detach / Re-link**: per-row controls in Settings → Discovery let you stop auto-managing an entry or re-point it at a different container when you migrate daemons.
 
 ---
@@ -62,6 +63,11 @@ discovery:
     network_filter: ""                      # optional: scope scans to one network
     host_ip: ""                             # required by host_port strategy
     refresh_interval: 60s                   # poller cadence, [10s, 1h]
+    auto_import: off                        # off (default) | add | update | sync (3.2.0)
+    lifecycle_enabled: false                # allow start/stop/restart of tracked containers (needs :rw socket)
+    lifecycle_min_role: admin               # min role for lifecycle controls
+    lifecycle_allowed_groups: []            # additionally require group membership
+    health_badge_placement: overview        # overview | overview_and_nav | off
 ```
 
 ### Make the daemon socket reachable from Muximux

--- a/docs/wiki/docker-discovery.md
+++ b/docs/wiki/docker-discovery.md
@@ -9,7 +9,7 @@ Connect Muximux to a Docker daemon and it can enumerate running containers, prop
 - **Scan**: lists running containers and proposes a name, icon, URL, port, and group for each, with confidence ratings (high / medium / low).
 - **Import**: one-click adds the chosen containers as apps in the menu, gateway subdomains, or both. Each row picks a routing mode: Direct URL, internal Proxy, or Gateway domain.
 - **Refresh**: a background poller (default 60s) re-resolves each tracked container against the daemon and rewrites the saved URL if the container's IP changes. Caddy reloads once per tick when gateway-site URLs change.
-- **Auto-import** (optional): with `discovery.docker.auto_import` set to `add`/`update`/`sync`, Muximux imports `muximux.*`-labeled containers with no modal and no click, and keeps them in step with the labels. Off by default. See [Automatic Import](#automatic-import).
+- **Auto-import** (optional): with `discovery.docker.auto_import` set to `add`/`update`/`sync`, Muximux imports `muximux.*`-labeled containers with no modal and no click. `add` imports each new labeled container once; `update` also re-syncs an imported app when its labels change; `sync` additionally removes an imported app when its container or labels disappear. Off by default. See [Automatic Import](#automatic-import).
 - **Detach / Re-link**: per-row controls in Settings → Discovery let you stop auto-managing an entry or re-point it at a different container when you migrate daemons.
 
 ---

--- a/docs/wiki/gateway-examples.md
+++ b/docs/wiki/gateway-examples.md
@@ -26,6 +26,20 @@ Expose ports 80 and 443 (Caddy needs both for ACME and HTTPS). Adding or removin
 
 The recipe sections below show the Caddyfile shape for each scenario; translate each into the corresponding `gateway_sites:` entry fields (see [Configuration Reference](configuration.md) for the full schema).
 
+### What `gateway_sites` supports
+
+Each gateway site proxies one `backend_url` per domain. The fields you can set are:
+
+- `backend_url` -- the `http://` or `https://` backend (no path, query, or transport flags)
+- `tls` -- certificate mode (`auto`, `none`, or `custom`)
+- `proxy_headers` -- extra headers sent to the backend
+- `forwarded_headers` -- emit `X-Forwarded-*` and `X-Real-IP` (default true)
+- `streaming` -- disable response buffering for streaming backends
+- `strip_frame_blockers` -- remove `X-Frame-Options`/CSP frame headers so the app can load in an iframe
+- `require_auth` / `min_role` / `allowed_groups` -- gate the site behind Muximux auth (see [Gateway Auth](gateway-auth.md))
+
+Anything outside this list (basic auth, rate limiting, subpath routing, wildcard host matching, custom `transport` flags) is not a gateway-site option. Those recipes are marked below and need an external proxy in front of Muximux.
+
 ---
 
 ## Basic Reverse Proxy
@@ -74,6 +88,8 @@ Each domain gets its own certificate. Caddy handles renewals automatically.
 
 If those backends run as Docker containers, **Apps tab → Discover from Docker** (or **Gateway tab → Discover from Docker**) builds the same site list in one click. Pick "Gateway" routing per row and supply the public domain; the gateway site is created and Caddy reloads in the same transaction. URLs auto-refresh as container IPs shift. See [Docker Discovery](docker-discovery.md).
 
+Or enable `discovery.docker.auto_import` so labeled containers appear automatically without opening the modal (see [Docker Discovery](docker-discovery.md)). Note: gateway-only label changes propagate in update/sync mode only when an app field also changes.
+
 Labels on your compose file pre-fill name, icon, port, and a stable tracking key:
 
 ```yaml
@@ -107,6 +123,17 @@ homeassistant.example.com {
 
 Some apps need specific headers to work behind a reverse proxy.
 
+On a gateway site, forwarded headers are emitted for you and arbitrary backend headers go in `proxy_headers`:
+
+```yaml
+gateway_sites:
+  - domain: app.example.com
+    backend_url: http://app:8080
+    proxy_headers:               # extra headers sent to the backend
+      X-Api-Key: "secret"
+    forwarded_headers: true      # X-Forwarded-* + X-Real-IP (default true; set false to suppress)
+```
+
 ### Plex
 
 Plex needs large header buffers and the real client IP:
@@ -124,19 +151,11 @@ plex.example.com {
 }
 ```
 
+> Not available via `gateway_sites`: this requires an external Caddy/nginx in front of Muximux. The embedded gateway only proxies one `backend_url` per domain. Forwarded headers (`X-Real-IP`, `X-Forwarded-*`) are emitted automatically; the custom `transport`/`read_buffer` tuning is not configurable on a gateway site.
+
 ### Proxmox
 
-Proxmox uses a self-signed certificate on its backend:
-
-```
-proxmox.example.com {
-    reverse_proxy https://localhost:8006 {
-        transport http {
-            tls_insecure_skip_verify
-        }
-    }
-}
-```
+> A self-signed HTTPS backend (e.g. Proxmox) cannot be served through a `gateway_sites` entry -- there is no insecure-skip-verify option. Front it with an external proxy, or add it to the dashboard as an app pointed at its direct URL with `open_mode: new_tab`.
 
 ### Vaultwarden
 
@@ -187,6 +206,8 @@ filebrowser.example.com {
 
 Generate a bcrypt hash with Caddy's own tool (`caddy hash-password`) or any bcrypt utility -- for example `htpasswd -nbBC 12 "" 'your-password' | cut -d: -f2`. Muximux's embedded Caddy is an internal runtime only and does not expose a CLI surface of its own.
 
+> Not available via `gateway_sites`: this requires an external Caddy/nginx in front of Muximux. The embedded gateway only proxies one `backend_url` per domain. To gate a site behind Muximux's own login instead, set `require_auth` on the gateway site (see [Gateway Auth](gateway-auth.md)).
+
 ---
 
 ## Rate Limiting
@@ -230,11 +251,15 @@ services.example.com {
 
 Make sure each service is configured to serve from the correct subpath (e.g., Grafana's `GF_SERVER_ROOT_URL=https://services.example.com/grafana/`).
 
+> Not available via `gateway_sites`: this requires an external Caddy/nginx in front of Muximux. The embedded gateway only proxies one `backend_url` per domain (no path or `handle` routing).
+
 ---
 
 ## Wildcard Domains
 
 If you use a wildcard DNS record (`*.example.com → your-server-ip`), you can add new services by just appending site blocks to the Caddyfile. No DNS changes needed per service.
+
+> Not available via `gateway_sites`: this requires an external Caddy/nginx in front of Muximux. The embedded gateway only proxies one `backend_url` per domain, with no wildcard host matching. Add each subdomain as its own gateway site instead.
 
 For wildcard TLS certificates, you need a DNS provider plugin for the ACME DNS-01 challenge:
 

--- a/docs/wiki/oidc-authentik.md
+++ b/docs/wiki/oidc-authentik.md
@@ -1,6 +1,6 @@
 # OIDC: Authentik
 
-This guide sets up Muximux to authenticate against Authentik, including emitting Authentik group memberships in the ID token so they're available to `admin_groups` (and, in a future release, per-app `allowed_groups`).
+This guide sets up Muximux to authenticate against Authentik, including emitting Authentik group memberships in the ID token so they're available to `admin_groups` and per-app `allowed_groups`.
 
 The end state: users sign in with their Authentik account, Muximux receives their groups as `groups: ["Engineering", "Muximux-Admins"]`, and admins land on Settings automatically.
 

--- a/docs/wiki/oidc-google.md
+++ b/docs/wiki/oidc-google.md
@@ -6,7 +6,7 @@ This guide sets up Muximux to authenticate with Google accounts via Google Cloud
 >
 > - Sign-in works fine for any Google account you allow.
 > - `admin_groups` will not promote users to admin based on Workspace groups. Instead, decide admin status by **email allowlist** (see Step 4) or by managing the Muximux user record manually after first login.
-> - The future per-app `allowed_groups` filtering will likewise not apply to Google-authenticated users.
+> - Per-app `allowed_groups` filtering likewise will not apply to Google-authenticated users (Google emits no groups).
 >
 > If you need group-based filtering, use Keycloak / Authentik / Pocket ID / Zitadel as a federated identity layer in front of Google instead. Most of those can use Google as an upstream identity source while still emitting their own `groups` claim downstream.
 

--- a/docs/wiki/oidc-keycloak.md
+++ b/docs/wiki/oidc-keycloak.md
@@ -1,6 +1,6 @@
 # OIDC: Keycloak
 
-This guide sets up Muximux to authenticate against a Keycloak realm, with group memberships emitted in the ID token so Muximux can promote users to admin and (in a future release) gate per-app visibility.
+This guide sets up Muximux to authenticate against a Keycloak realm, with group memberships emitted in the ID token so Muximux can promote users to admin and gate per-app visibility.
 
 The end state: users sign in with their Keycloak account, Muximux receives their group list as `groups: ["developers", "Muximux-Admins"]`, and admins land on the Settings page automatically.
 

--- a/docs/wiki/security.md
+++ b/docs/wiki/security.md
@@ -154,7 +154,7 @@ For transparency, here are ASVS categories that are not applicable to Muximux's 
 | LDAP injection | No LDAP integration |
 | SMS/phone OTP | Not offered as an auth method |
 | Hardware security modules | Self-hosted single-binary app |
-| File upload malware scanning | No untrusted user file uploads. Custom-icon upload (PNG/SVG/JPG/WebP, 2 MB cap, admin-only, type-validated) and config import are the only upload paths; both are size-limited and validated. |
+| File upload malware scanning | No untrusted user file uploads. Custom-icon upload (PNG/SVG/JPG/WebP/GIF, 2 MB cap, admin-only, type-validated) and config import are the only upload paths; both are size-limited and validated. |
 | Multi-tenant data isolation | Single-tenant application |
 | WebSocket message authentication | WebSocket is used for read-only log streaming, not commands |
 

--- a/docs/wiki/security.md
+++ b/docs/wiki/security.md
@@ -154,7 +154,7 @@ For transparency, here are ASVS categories that are not applicable to Muximux's 
 | LDAP injection | No LDAP integration |
 | SMS/phone OTP | Not offered as an auth method |
 | Hardware security modules | Self-hosted single-binary app |
-| File upload malware scanning | No user file uploads (only config import and icon caching) |
+| File upload malware scanning | No untrusted user file uploads. Custom-icon upload (PNG/SVG/JPG/WebP, 2 MB cap, admin-only, type-validated) and config import are the only upload paths; both are size-limited and validated. |
 | Multi-tenant data isolation | Single-tenant application |
 | WebSocket message authentication | WebSocket is used for read-only log streaming, not commands |
 
@@ -169,6 +169,15 @@ For transparency, here are ASVS categories that are not applicable to Muximux's 
 5. **Use the reverse proxy for sensitive apps** -- Set `proxy: true` on apps that should be gated behind Muximux's authentication.
 6. **Restrict network access** -- In a homelab, consider running Muximux on an internal network or behind a VPN for defense-in-depth.
 7. **Monitor audit logs** -- Filter for `source=audit` in the log viewer to track authentication and configuration events.
+8. **Treat the Docker socket as privileged** -- Mount it read-only
+   (`:ro`) for discovery/auto-import; only grant write access (`:rw`) if you
+   enable lifecycle controls (`discovery.docker.lifecycle_enabled`), which let
+   authorized users start/stop/restart containers (role-gated, audit-logged).
+9. **Auto-import is opt-in** -- It is off by default. Enabling
+   `discovery.docker.auto_import` imports every labeled container without a
+   click, including any exposed via public gateway subdomains; review labels
+   before turning it on, and use `muximux.app.enabled=false` to opt a
+   container out.
 
 ---
 

--- a/docs/wiki/troubleshooting.md
+++ b/docs/wiki/troubleshooting.md
@@ -254,3 +254,23 @@ services:
     volumes:
       - ./data:/app/data
 ```
+
+---
+
+## Docker Discovery Finds Nothing / Lifecycle Buttons Fail
+
+**Symptom:** The Discover modal is empty, auto-import imports nothing, or the
+start/stop/restart buttons return an error.
+
+**Cause:** Muximux can't reach the Docker socket.
+
+**Solutions:**
+1. Mount the socket. Discovery and auto-import need it read-only:
+   `- /var/run/docker.sock:/var/run/docker.sock:ro`
+   The container entrypoint auto-detects the socket's group and grants the
+   runtime user access -- no `group_add`, root, or custom entrypoint needed.
+2. Lifecycle controls (start/stop/restart) additionally require write access
+   (`:rw`) AND `discovery.docker.lifecycle_enabled: true`. They are role-gated
+   and audit-logged.
+3. Confirm discovery is enabled (`discovery.docker.enabled: true`) and check
+   the server logs for socket connection errors on startup.

--- a/docs/wiki/troubleshooting.md
+++ b/docs/wiki/troubleshooting.md
@@ -274,3 +274,6 @@ start/stop/restart buttons return an error.
    and audit-logged.
 3. Confirm discovery is enabled (`discovery.docker.enabled: true`) and check
    the server logs for socket connection errors on startup.
+4. For rootless Docker, a docker-socket-proxy sidecar, or a custom socket
+   path, set the `DOCKER_SOCKET` and `DOCKER_GID` override env vars (see
+   [Docker Discovery](docker-discovery.md#make-the-daemon-socket-reachable-from-muximux)).


### PR DESCRIPTION
A cross-doc audit (4 parallel reviewers) bringing every wiki page and the repo examples up to date with 3.2.0.

**Discovery / config:** document `auto_import` (3.2.0) + the lifecycle keys in the discovery config blocks; add `http_action` to `open_mode` lists; note the automatic-import path alongside the manual Discover modal (docker-discovery, configuration, apps, docker-compose).
**Gateway examples:** add a "what `gateway_sites` supports" callout; flag recipes with no `gateway_sites` equivalent (basic auth, subpath, wildcard, transport flags); fix the Proxmox self-signed-backend contradiction; add a `proxy_headers`/`forwarded_headers` example.
**API reference:** document the Discovery, Gateway, `http_action`, lifecycle, and API-key endpoints (registered but undocumented); fix the stale log `source` filter list; refresh the update-check example to 3.2.0.
**Troubleshooting:** new Docker-discovery / socket section.
**Security:** note the Docker-socket-as-privileged posture and that auto-import is opt-in; correct the `No user file uploads` claim (admin custom-icon upload exists).
**OIDC (authentik/google/keycloak):** drop stale `future release` framing for the shipped per-app `allowed_groups`.

16 of 33 wiki pages were already fully current. Docs-only; syncs to the GitHub wiki on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API and configuration references with new Docker discovery, gateway management, per-app launch actions, and enhanced logs options.
  * Added clearer guides for Docker-labeled auto-import behavior, gateway-site capabilities/limitations, app open modes, and updated OIDC group/allowed-groups behavior.
  * Improved security recommendations for deployers, including Docker socket handling and opt-in auto-import notes.
  * Added troubleshooting documentation for “Docker discovery finds nothing” and Docker lifecycle button failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->