### PR TITLE
Close 3.2.0 gaps: gateway-only label propagation, self-signed backends, proxy rewriter audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Muximux are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Auto-import `update`/`sync` now re-syncs a container's **gateway site**, not
+  only its app. Gateway-only label changes -- `muximux.gateway.require_auth`,
+  `min_role`, `allowed_groups`, `streaming`, `strip_frame_blockers`, and
+  `forwarded_headers` -- propagate on the next tick without an app field also
+  having to change (the 3.2.0 known limitation). Removing a container's
+  `muximux.app.gateway.domain` label reverts its app to the direct container
+  URL and drops the now-orphaned gateway site.
+
 ## [3.2.0] - 2026-06-30
 
 Hands-off Docker discovery. 3.1.0 taught Muximux to read your daemon and import containers as apps with one click; 3.2.0 can do it automatically. Label a container with the `muximux.*` keys you already use, set one flag, and Muximux imports it (and optionally its gateway subdomain) with no manual step. A GitOps-friendly addition that stays off by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Muximux are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Gateway sites can skip backend TLS verification** via a new
+  `backend_skip_tls_verify` field (label: `muximux.gateway.skip_tls_verify`,
+  or the "Skip backend TLS verification" toggle in Settings -> Gateway). It
+  only takes effect when the backend URL is https, and lets the embedded
+  gateway front backends that serve a self-signed or otherwise untrusted
+  certificate -- Proxmox on `:8006`, for example -- which previously had to
+  be reached through an external proxy. The public-facing certificate is
+  unaffected.
+
 ### Fixed
 - Auto-import `update`/`sync` now re-syncs a container's **gateway site**, not
   only its app. Gateway-only label changes -- `muximux.gateway.require_auth`,

--- a/docs/wiki/configuration.md
+++ b/docs/wiki/configuration.md
@@ -64,6 +64,7 @@ server:
       streaming: false                   # disable Caddy response buffering for live data
       strip_frame_blockers: true         # strip X-Frame-Options for iframe embedding
       forwarded_headers: true            # forward X-Forwarded-Proto/Host/Real-IP
+      backend_skip_tls_verify: false     # skip verifying a self-signed HTTPS backend (Proxmox); https backends only
       proxy_headers: {}                  # extra headers injected on upstream requests
       # Optional: also surface this site in the dashboard menu
       app_name: ""                       # link to an existing app by name

--- a/docs/wiki/docker-discovery.md
+++ b/docs/wiki/docker-discovery.md
@@ -359,6 +359,7 @@ Omit the label to fall back to the catalog icon. Only Dashboard Icons slugs work
 | `muximux.gateway.streaming` | bool | `false` | Disable Caddy response buffering for live-streaming backends. |
 | `muximux.gateway.strip_frame_blockers` | bool | `true` | Drop `X-Frame-Options` / `Content-Security-Policy: frame-ancestors` on responses so the site can be iframed elsewhere. |
 | `muximux.gateway.forwarded_headers` | bool | `true` | Forward `X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Real-IP`. Turn off only when your backend has its own handling. |
+| `muximux.gateway.skip_tls_verify` | bool | `false` | Skip verification of the backend's TLS certificate. Only takes effect when the backend URL is `https` -- use it for self-signed / untrusted backends like Proxmox on `:8006`. Leaves the public-facing certificate unaffected. |
 | `muximux.gateway.require_auth` | bool | `false` | Gate the subdomain behind Muximux's login. Visitors land on `/login` first; admins bypass per-site role / group rules. Requires `server.session_cookie_domain` to be set. |
 | `muximux.gateway.min_role` | `user` \| `power-user` \| `admin` | unset | When `require_auth=true`, minimum role to access the site. |
 | `muximux.gateway.allowed_groups` | csv | unset | When `require_auth=true`, allow-list groups (comma-separated, case-insensitive). |

--- a/docs/wiki/docker-discovery.md
+++ b/docs/wiki/docker-discovery.md
@@ -411,11 +411,11 @@ Auto-import never silently clobbers a URL you took manual control of. **Changing
 
 Other managed-field edits (name, icon, group, and similar) do **not** detach. Under `update`/`sync` they are re-synced from the labels on the next tick, so the labels remain the source of truth; under `add` they stick, because `add` never re-syncs an already-imported app.
 
-### Known limitation -- gateway-only labels and `update`/`sync`
+### Gateway labels and `update`/`sync`
 
-In `update` and `sync`, re-sync compares the **app** fields built from labels against the stored app. Gateway labels that change the app's URL -- `muximux.app.gateway.domain` and `muximux.gateway.tls` -- do change an app field, so edits to them **do** propagate on the next tick.
+In `update` and `sync`, re-sync compares both the **app** fields and the **gateway site** built from labels against what is stored. Gateway labels that change the app's URL -- `muximux.app.gateway.domain` and `muximux.gateway.tls` -- and gateway-**only** labels that do not map to any app field -- `muximux.gateway.require_auth`, `muximux.gateway.min_role`, `muximux.gateway.allowed_groups`, `muximux.gateway.streaming`, `muximux.gateway.strip_frame_blockers`, and `muximux.gateway.forwarded_headers` -- all propagate on the next tick. Toggling `muximux.gateway.require_auth` on a running container, for example, is re-synced without any app-field change.
 
-Gateway-**only** labels that do not map to any app field -- `muximux.gateway.require_auth`, `muximux.gateway.min_role`, `muximux.gateway.streaming`, `muximux.gateway.strip_frame_blockers`, and `muximux.gateway.forwarded_headers` -- are **not** picked up by re-sync. Changing one of these labels on a running, already-imported container has no effect until either an app field also changes, or you remove and re-add the container (which re-imports it from scratch). So if you rely on, say, toggling `muximux.gateway.require_auth` via a label, know that auto-import will not apply that toggle on its own.
+Removing the `muximux.app.gateway.domain` label from an already-imported container reverts its app to the direct container URL and drops the now-orphaned gateway site on the next tick.
 
 ---
 

--- a/docs/wiki/docker-discovery.md
+++ b/docs/wiki/docker-discovery.md
@@ -414,7 +414,7 @@ Other managed-field edits (name, icon, group, and similar) do **not** detach. Un
 
 ### Gateway labels and `update`/`sync`
 
-In `update` and `sync`, re-sync compares both the **app** fields and the **gateway site** built from labels against what is stored. Gateway labels that change the app's URL -- `muximux.app.gateway.domain` and `muximux.gateway.tls` -- and gateway-**only** labels that do not map to any app field -- `muximux.gateway.require_auth`, `muximux.gateway.min_role`, `muximux.gateway.allowed_groups`, `muximux.gateway.streaming`, `muximux.gateway.strip_frame_blockers`, and `muximux.gateway.forwarded_headers` -- all propagate on the next tick. Toggling `muximux.gateway.require_auth` on a running container, for example, is re-synced without any app-field change.
+In `update` and `sync`, re-sync compares both the **app** fields and the **gateway site** built from labels against what is stored. Gateway labels that change the app's URL -- `muximux.app.gateway.domain` and `muximux.gateway.tls` -- and gateway-**only** labels that do not map to any app field -- `muximux.gateway.require_auth`, `muximux.gateway.min_role`, `muximux.gateway.allowed_groups`, `muximux.gateway.streaming`, `muximux.gateway.strip_frame_blockers`, `muximux.gateway.forwarded_headers`, and `muximux.gateway.skip_tls_verify` -- all propagate on the next tick. Toggling `muximux.gateway.require_auth` on a running container, for example, is re-synced without any app-field change.
 
 Removing the `muximux.app.gateway.domain` label from an already-imported container reverts its app to the direct container URL and drops the now-orphaned gateway site on the next tick.
 

--- a/docs/wiki/gateway-examples.md
+++ b/docs/wiki/gateway-examples.md
@@ -36,9 +36,10 @@ Each gateway site proxies one `backend_url` per domain. The fields you can set a
 - `forwarded_headers` -- emit `X-Forwarded-*` and `X-Real-IP` (default true)
 - `streaming` -- disable response buffering for streaming backends
 - `strip_frame_blockers` -- remove `X-Frame-Options`/CSP frame headers so the app can load in an iframe
+- `backend_skip_tls_verify` -- skip verifying a self-signed / untrusted `https` backend certificate (e.g. Proxmox)
 - `require_auth` / `min_role` / `allowed_groups` -- gate the site behind Muximux auth (see [Gateway Auth](gateway-auth.md))
 
-Anything outside this list (basic auth, rate limiting, subpath routing, wildcard host matching, custom `transport` flags) is not a gateway-site option. Those recipes are marked below and need an external proxy in front of Muximux.
+Anything outside this list (basic auth, rate limiting, subpath routing, wildcard host matching, arbitrary `transport` tuning like `read_buffer`) is not a gateway-site option. Those recipes are marked below and need an external proxy in front of Muximux.
 
 ---
 
@@ -155,7 +156,17 @@ plex.example.com {
 
 ### Proxmox
 
-> A self-signed HTTPS backend (e.g. Proxmox) cannot be served through a `gateway_sites` entry -- there is no insecure-skip-verify option. Front it with an external proxy, or add it to the dashboard as an app pointed at its direct URL with `open_mode: new_tab`.
+Proxmox serves its web UI on `:8006` with a self-signed certificate. Set `backend_skip_tls_verify: true` so the gateway does not reject that certificate:
+
+```yaml
+gateway_sites:
+  - domain: proxmox.example.com
+    backend_url: https://192.168.1.10:8006   # https + self-signed
+    tls: auto
+    backend_skip_tls_verify: true            # skip verifying the backend cert
+```
+
+`backend_skip_tls_verify` only applies to an `https://` `backend_url`, and affects the gateway-to-backend hop only -- the public-facing certificate Caddy serves for `proxmox.example.com` is unaffected. (Label form: `muximux.gateway.skip_tls_verify=true`.)
 
 ### Vaultwarden
 
@@ -384,7 +395,7 @@ apps:
     enabled: true
 ```
 
-Gateway sites only accept an `http://` or `https://` `backend_url` with no path, query, or extra transport flags. A backend that serves a self-signed HTTPS certificate (like Proxmox) can't be verified through a gateway site, so reach it some other way -- here Proxmox is added as a dashboard app pointed at an external proxy or its direct URL rather than a gateway site.
+Gateway sites only accept an `http://` or `https://` `backend_url` with no path, query, or subpath routing. Proxmox is shown here as a `new_tab` dashboard app because its UI does not embed in an iframe -- but it could equally be a gateway site, since its self-signed backend is handled by `backend_skip_tls_verify` (see the Proxmox recipe above).
 
 **`docker-compose.yml`:**
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,13 @@ type GatewaySite struct {
 	// Jellyfin, Grafana, Home Assistant: on. Most apps: leave off.
 	Streaming bool `yaml:"streaming,omitempty" json:"streaming,omitempty"`
 
+	// BackendSkipTLSVerify disables verification of the backend's TLS
+	// certificate (Caddy `transport http { tls_insecure_skip_verify }`).
+	// It only takes effect when BackendURL is https; use it for backends
+	// that serve a self-signed or otherwise untrusted certificate, such
+	// as Proxmox on :8006. Leaves the public-facing TLS unaffected.
+	BackendSkipTLSVerify bool `yaml:"backend_skip_tls_verify,omitempty" json:"backend_skip_tls_verify,omitempty"`
+
 	// ProxyHeaders are HTTP headers injected on the upstream request.
 	// Use to forward backend API keys, Authorization tokens, etc.
 	ProxyHeaders map[string]string `yaml:"proxy_headers,omitempty" json:"proxy_headers,omitempty"`

--- a/internal/discovery/autoimport.go
+++ b/internal/discovery/autoimport.go
@@ -164,14 +164,17 @@ type ReconcilePlan struct {
 //   - off mode: empty plan, no work.
 //   - desired key with no current app: Add (every non-off mode).
 //   - desired key whose current app is auto-imported and differs in a
-//     label-controlled field: Update (update/sync only, never add mode).
+//     label-controlled field, OR whose gateway site differs: Update
+//     (update/sync only, never add mode). The site diff makes gateway-
+//     only label changes (require_auth, min_role, streaming, ...)
+//     propagate even when no app field changed.
 //   - desired key whose current app exists but is not auto-imported
 //     (manual or detached): left untouched; it still suppresses the Add
 //     so no duplicate app is created.
 //   - sync only: a current auto-imported app whose DockerKey is absent
 //     from the desired set has its key listed in RemoveKeys. Apps without
 //     DockerAutoImported are never updated or removed.
-func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.AppConfig) ReconcilePlan {
+func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.AppConfig, currentSites []config.GatewaySite) ReconcilePlan {
 	var plan ReconcilePlan
 	if mode == config.AutoImportOff {
 		return plan
@@ -183,6 +186,15 @@ func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.A
 			curByKey[current[i].DockerKey] = current[i]
 		}
 	}
+	// Sites are keyed by the same DockerKey as their app, so a gateway-
+	// only label change can be diffed even when the app fields are
+	// untouched.
+	curSiteByKey := make(map[string]config.GatewaySite, len(currentSites))
+	for i := range currentSites {
+		if currentSites[i].DockerKey != "" {
+			curSiteByKey[currentSites[i].DockerKey] = currentSites[i]
+		}
+	}
 	desiredKeys := make(map[string]bool, len(desired))
 
 	for i := range desired {
@@ -192,7 +204,8 @@ func Reconcile(mode config.AutoImportMode, desired []Desired, current []config.A
 		switch {
 		case !exists:
 			plan.Add = append(plan.Add, desired[i])
-		case cur.DockerAutoImported && mode != config.AutoImportAdd && !sameManagedFields(&cur, &desired[i].App):
+		case cur.DockerAutoImported && mode != config.AutoImportAdd &&
+			(!sameManagedFields(&cur, &desired[i].App) || gatewaySiteChanged(desired[i].Site, curSiteByKey, k)):
 			plan.Update = append(plan.Update, desired[i])
 		default:
 			// Manual/detached app, add mode, or unchanged auto app:
@@ -241,4 +254,39 @@ func sameManagedFields(a, b *config.AppConfig) bool {
 		reflect.DeepEqual(a.AllowedGroups, b.AllowedGroups) &&
 		reflect.DeepEqual(a.Permissions, b.Permissions) &&
 		reflect.DeepEqual(a.HTTPActionHeaders, b.HTTPActionHeaders)
+}
+
+// gatewaySiteChanged reports whether the desired gateway site for a key
+// differs from the current one. It also fires on presence changes: a
+// gateway domain newly added to (or dropped from) an already-tracked
+// container. Returns false only when neither side has a site.
+func gatewaySiteChanged(desiredSite *config.GatewaySite, currentByKey map[string]config.GatewaySite, key string) bool {
+	curSite, hasCur := currentByKey[key]
+	switch {
+	case desiredSite == nil && !hasCur:
+		return false
+	case desiredSite == nil || !hasCur:
+		return true // one side has a site, the other does not
+	default:
+		return !sameGatewaySiteManagedFields(desiredSite, &curSite)
+	}
+}
+
+// sameGatewaySiteManagedFields compares only the site fields that
+// BuildDesired derives from labels (AppName comes from the name label).
+// BackendURL is deliberately excluded: it tracks the container IP and is
+// owned by the URL-refresh pass, not the label diff, so comparing it here
+// would fight that pass on every IP change. Tracking fields (DockerKey/
+// Endpoint/Strategy/ManagedURL) and fields with no label vocabulary
+// (TLSCert/TLSKey/ProxyHeaders) are not label-controlled and excluded.
+func sameGatewaySiteManagedFields(a, b *config.GatewaySite) bool {
+	return a.Domain == b.Domain &&
+		a.TLS == b.TLS &&
+		a.AppName == b.AppName &&
+		a.StripFrameBlockers == b.StripFrameBlockers &&
+		a.Streaming == b.Streaming &&
+		a.RequireAuth == b.RequireAuth &&
+		a.MinRole == b.MinRole &&
+		reflect.DeepEqual(a.ForwardedHeaders, b.ForwardedHeaders) &&
+		reflect.DeepEqual(a.AllowedGroups, b.AllowedGroups)
 }

--- a/internal/discovery/autoimport.go
+++ b/internal/discovery/autoimport.go
@@ -126,6 +126,9 @@ func buildGatewaySite(sug *Suggestion, endpoint string) *config.GatewaySite {
 			site.StripFrameBlockers = *gw.StripFrameBlockers
 		}
 		site.ForwardedHeaders = gw.ForwardedHeaders
+		if gw.SkipTLSVerify != nil {
+			site.BackendSkipTLSVerify = *gw.SkipTLSVerify
+		}
 		if gw.RequireAuth != nil {
 			site.RequireAuth = *gw.RequireAuth
 		}
@@ -285,6 +288,7 @@ func sameGatewaySiteManagedFields(a, b *config.GatewaySite) bool {
 		a.AppName == b.AppName &&
 		a.StripFrameBlockers == b.StripFrameBlockers &&
 		a.Streaming == b.Streaming &&
+		a.BackendSkipTLSVerify == b.BackendSkipTLSVerify &&
 		a.RequireAuth == b.RequireAuth &&
 		a.MinRole == b.MinRole &&
 		reflect.DeepEqual(a.ForwardedHeaders, b.ForwardedHeaders) &&

--- a/internal/discovery/autoimport_test.go
+++ b/internal/discovery/autoimport_test.go
@@ -302,7 +302,7 @@ func desire(k string) Desired {
 
 // TestReconcile_Off: off mode is a no-op regardless of inputs.
 func TestReconcile_Off(t *testing.T) {
-	p := Reconcile(config.AutoImportOff, []Desired{desire("a")}, []config.AppConfig{autoKey("gone")})
+	p := Reconcile(config.AutoImportOff, []Desired{desire("a")}, []config.AppConfig{autoKey("gone")}, nil)
 	if len(p.Add) != 0 || len(p.Update) != 0 || len(p.RemoveKeys) != 0 {
 		t.Errorf("off mode must be a no-op: %+v", p)
 	}
@@ -313,7 +313,7 @@ func TestReconcile_Off(t *testing.T) {
 func TestReconcile_Modes(t *testing.T) {
 	// add: new key with no current app -> Add, in every non-off mode
 	for _, m := range []config.AutoImportMode{config.AutoImportAdd, config.AutoImportUpdate, config.AutoImportSync} {
-		p := Reconcile(m, []Desired{desire("a")}, nil)
+		p := Reconcile(m, []Desired{desire("a")}, nil, nil)
 		if len(p.Add) != 1 || len(p.Update) != 0 || len(p.RemoveKeys) != 0 {
 			t.Errorf("%s add: %+v", m, p)
 		}
@@ -321,24 +321,24 @@ func TestReconcile_Modes(t *testing.T) {
 
 	// vanished auto app: removed only in sync
 	cur := []config.AppConfig{autoKey("gone")}
-	if p := Reconcile(config.AutoImportAdd, nil, cur); len(p.RemoveKeys) != 0 {
+	if p := Reconcile(config.AutoImportAdd, nil, cur, nil); len(p.RemoveKeys) != 0 {
 		t.Errorf("add must not remove: %+v", p)
 	}
-	if p := Reconcile(config.AutoImportUpdate, nil, cur); len(p.RemoveKeys) != 0 {
+	if p := Reconcile(config.AutoImportUpdate, nil, cur, nil); len(p.RemoveKeys) != 0 {
 		t.Errorf("update must not remove: %+v", p)
 	}
-	if p := Reconcile(config.AutoImportSync, nil, cur); len(p.RemoveKeys) != 1 || p.RemoveKeys[0] != "gone" {
+	if p := Reconcile(config.AutoImportSync, nil, cur, nil); len(p.RemoveKeys) != 1 || p.RemoveKeys[0] != "gone" {
 		t.Errorf("sync must remove vanished auto app: %+v", p)
 	}
 
 	// manual app present for a key: never removed, never duplicated
 	man := []config.AppConfig{key("m")} // no DockerAutoImported
-	p := Reconcile(config.AutoImportSync, []Desired{desire("m")}, man)
+	p := Reconcile(config.AutoImportSync, []Desired{desire("m")}, man, nil)
 	if len(p.Add) != 0 || len(p.Update) != 0 || len(p.RemoveKeys) != 0 {
 		t.Errorf("manual app must be untouched and block add: %+v", p)
 	}
 	// and a manual app whose container vanished is NOT removed in sync
-	p = Reconcile(config.AutoImportSync, nil, man)
+	p = Reconcile(config.AutoImportSync, nil, man, nil)
 	if len(p.RemoveKeys) != 0 {
 		t.Errorf("sync must not remove a manual app: %+v", p)
 	}
@@ -349,7 +349,7 @@ func TestReconcile_Modes(t *testing.T) {
 // when the desired app's label fields differ from it.
 func TestReconcile_DetachedAppNotRecreated(t *testing.T) {
 	detached := key("d") // DockerKey set, auto false; differs from desire("d")
-	p := Reconcile(config.AutoImportSync, []Desired{desire("d")}, []config.AppConfig{detached})
+	p := Reconcile(config.AutoImportSync, []Desired{desire("d")}, []config.AppConfig{detached}, nil)
 	if len(p.Add) != 0 {
 		t.Errorf("detached app must suppress add: %+v", p)
 	}
@@ -368,20 +368,126 @@ func TestReconcile_UpdateOnlyWhenChanged(t *testing.T) {
 	cur.DockerAutoImported = true
 	// identical desired -> no update
 	same := []Desired{{App: cur}}
-	if p := Reconcile(config.AutoImportUpdate, same, []config.AppConfig{cur}); len(p.Update) != 0 {
+	if p := Reconcile(config.AutoImportUpdate, same, []config.AppConfig{cur}, nil); len(p.Update) != 0 {
 		t.Errorf("unchanged should not update: %+v", p)
 	}
 	// changed name -> update
 	changed := BuildDesired(&Suggestion{Key: "u", Name: "U2", URL: "http://h:1"}, "e")
-	if p := Reconcile(config.AutoImportUpdate, []Desired{changed}, []config.AppConfig{cur}); len(p.Update) != 1 {
+	if p := Reconcile(config.AutoImportUpdate, []Desired{changed}, []config.AppConfig{cur}, nil); len(p.Update) != 1 {
 		t.Errorf("changed should update: %+v", p)
 	}
-	if p := Reconcile(config.AutoImportSync, []Desired{changed}, []config.AppConfig{cur}); len(p.Update) != 1 {
+	if p := Reconcile(config.AutoImportSync, []Desired{changed}, []config.AppConfig{cur}, nil); len(p.Update) != 1 {
 		t.Errorf("sync should update changed app: %+v", p)
 	}
 	// update suppressed in add mode even when changed
-	if p := Reconcile(config.AutoImportAdd, []Desired{changed}, []config.AppConfig{cur}); len(p.Update) != 0 {
+	if p := Reconcile(config.AutoImportAdd, []Desired{changed}, []config.AppConfig{cur}, nil); len(p.Update) != 0 {
 		t.Errorf("add mode must not update: %+v", p)
+	}
+}
+
+// gwDesire builds an auto-imported gateway Desired for key k with the
+// given auth gate, for exercising site-only reconcile diffs.
+func gwDesire(k string, requireAuth bool, minRole string) Desired {
+	ra := requireAuth
+	d := BuildDesired(&Suggestion{
+		Key: k, Name: k, URL: "http://h:1",
+		EffectiveStrategy: config.StrategyContainerIP,
+		SuggestedDomain:   k + ".example.com",
+		SuggestedGateway: &SuggestedGatewayConfig{
+			TLS: "auto", RequireAuth: &ra, MinRole: minRole,
+		},
+	}, "e")
+	d.App.DockerAutoImported = true
+	return d
+}
+
+// TestReconcile_GatewaySiteFieldChange: a gateway-only label change
+// (require_auth) with unchanged app fields must still produce an Update,
+// in update/sync but never add. This is the gap #1 closes.
+func TestReconcile_GatewaySiteFieldChange(t *testing.T) {
+	cur := gwDesire("g", false, "admin")
+	curApps := []config.AppConfig{cur.App}
+	curSites := []config.GatewaySite{*cur.Site}
+
+	des := gwDesire("g", true, "admin") // only require_auth flips
+	if !sameManagedFields(&cur.App, &des.App) {
+		t.Fatal("precondition: app fields must be identical so only the site differs")
+	}
+
+	for _, m := range []config.AutoImportMode{config.AutoImportUpdate, config.AutoImportSync} {
+		p := Reconcile(m, []Desired{des}, curApps, curSites)
+		if len(p.Update) != 1 {
+			t.Errorf("%s: gateway-only change must update: %+v", m, p)
+		}
+	}
+	if p := Reconcile(config.AutoImportAdd, []Desired{des}, curApps, curSites); len(p.Update) != 0 {
+		t.Errorf("add mode must not update on site change: %+v", p)
+	}
+	// Identical site -> no update.
+	if p := Reconcile(config.AutoImportUpdate, []Desired{cur}, curApps, curSites); len(p.Update) != 0 {
+		t.Errorf("identical site must not update: %+v", p)
+	}
+}
+
+// TestReconcile_GatewayDomainDropped: when a tracked gateway container
+// loses its domain label it now routes directly (Site nil). The presence
+// change must produce an Update so the app is rewritten and the orphaned
+// site can be cleaned up downstream.
+func TestReconcile_GatewayDomainDropped(t *testing.T) {
+	cur := gwDesire("g", true, "admin")
+	curApps := []config.AppConfig{cur.App}
+	curSites := []config.GatewaySite{*cur.Site}
+
+	direct := BuildDesired(&Suggestion{Key: "g", Name: "g", URL: "http://h:1"}, "e")
+	direct.App.DockerAutoImported = true
+	if direct.Site != nil {
+		t.Fatal("precondition: dropped-domain desired must have no site")
+	}
+	if p := Reconcile(config.AutoImportUpdate, []Desired{direct}, curApps, curSites); len(p.Update) != 1 {
+		t.Errorf("dropping a gateway domain must update: %+v", p)
+	}
+}
+
+// TestSameGatewaySiteManagedFields: each label-derived site field flips
+// the result; BackendURL and tracking fields (IP/URL-refresh owned) do
+// not, so an IP change alone never looks like a label change.
+func TestSameGatewaySiteManagedFields(t *testing.T) {
+	fwd := false
+	base := config.GatewaySite{
+		Domain: "g.example.com", TLS: config.TLSModeAuto, AppName: "G",
+		StripFrameBlockers: true, Streaming: true, RequireAuth: true,
+		MinRole: "admin", ForwardedHeaders: &fwd, AllowedGroups: []string{"staff"},
+	}
+	if !sameGatewaySiteManagedFields(&base, &base) {
+		t.Fatal("identical sites must be same")
+	}
+
+	unrelated := base
+	unrelated.BackendURL = "http://changed:9"
+	unrelated.DockerManagedURL = "http://changed:9"
+	unrelated.DockerKey = "other"
+	unrelated.DockerEndpoint = "other"
+	if !sameGatewaySiteManagedFields(&base, &unrelated) {
+		t.Error("backend/tracking fields must not register as a managed difference")
+	}
+
+	mutators := map[string]func(*config.GatewaySite){
+		"Domain":             func(s *config.GatewaySite) { s.Domain = "z" },
+		"TLS":                func(s *config.GatewaySite) { s.TLS = config.TLSModeNone },
+		"AppName":            func(s *config.GatewaySite) { s.AppName = "Z" },
+		"StripFrameBlockers": func(s *config.GatewaySite) { s.StripFrameBlockers = false },
+		"Streaming":          func(s *config.GatewaySite) { s.Streaming = false },
+		"RequireAuth":        func(s *config.GatewaySite) { s.RequireAuth = false },
+		"MinRole":            func(s *config.GatewaySite) { s.MinRole = "user" },
+		"ForwardedHeaders":   func(s *config.GatewaySite) { tv := true; s.ForwardedHeaders = &tv },
+		"AllowedGroups":      func(s *config.GatewaySite) { s.AllowedGroups = []string{"other"} },
+	}
+	for name, mut := range mutators {
+		mod := base
+		mut(&mod)
+		if sameGatewaySiteManagedFields(&base, &mod) {
+			t.Errorf("flipping %s must register as a managed difference", name)
+		}
 	}
 }
 

--- a/internal/discovery/autoimport_test.go
+++ b/internal/discovery/autoimport_test.go
@@ -111,6 +111,7 @@ func TestBuildDesired_GatewaySite(t *testing.T) {
 			Streaming:          &yes,
 			StripFrameBlockers: &yes,
 			ForwardedHeaders:   &no,
+			SkipTLSVerify:      &yes,
 			RequireAuth:        &yes,
 			MinRole:            "power-user",
 			AllowedGroups:      []string{"staff"},
@@ -137,6 +138,9 @@ func TestBuildDesired_GatewaySite(t *testing.T) {
 	}
 	if !d.Site.RequireAuth || d.Site.MinRole != "power-user" || len(d.Site.AllowedGroups) != 1 {
 		t.Errorf("auth gate not mapped: %+v", d.Site)
+	}
+	if !d.Site.BackendSkipTLSVerify {
+		t.Errorf("skip_tls_verify label must map to site.BackendSkipTLSVerify: %+v", d.Site)
 	}
 	if d.Site.DockerKey != "label:sonarr" {
 		t.Errorf("site must carry tracking key, got %q", d.Site.DockerKey)
@@ -455,8 +459,9 @@ func TestSameGatewaySiteManagedFields(t *testing.T) {
 	fwd := false
 	base := config.GatewaySite{
 		Domain: "g.example.com", TLS: config.TLSModeAuto, AppName: "G",
-		StripFrameBlockers: true, Streaming: true, RequireAuth: true,
-		MinRole: "admin", ForwardedHeaders: &fwd, AllowedGroups: []string{"staff"},
+		StripFrameBlockers: true, Streaming: true, BackendSkipTLSVerify: true,
+		RequireAuth: true, MinRole: "admin", ForwardedHeaders: &fwd,
+		AllowedGroups: []string{"staff"},
 	}
 	if !sameGatewaySiteManagedFields(&base, &base) {
 		t.Fatal("identical sites must be same")
@@ -472,15 +477,16 @@ func TestSameGatewaySiteManagedFields(t *testing.T) {
 	}
 
 	mutators := map[string]func(*config.GatewaySite){
-		"Domain":             func(s *config.GatewaySite) { s.Domain = "z" },
-		"TLS":                func(s *config.GatewaySite) { s.TLS = config.TLSModeNone },
-		"AppName":            func(s *config.GatewaySite) { s.AppName = "Z" },
-		"StripFrameBlockers": func(s *config.GatewaySite) { s.StripFrameBlockers = false },
-		"Streaming":          func(s *config.GatewaySite) { s.Streaming = false },
-		"RequireAuth":        func(s *config.GatewaySite) { s.RequireAuth = false },
-		"MinRole":            func(s *config.GatewaySite) { s.MinRole = "user" },
-		"ForwardedHeaders":   func(s *config.GatewaySite) { tv := true; s.ForwardedHeaders = &tv },
-		"AllowedGroups":      func(s *config.GatewaySite) { s.AllowedGroups = []string{"other"} },
+		"Domain":               func(s *config.GatewaySite) { s.Domain = "z" },
+		"TLS":                  func(s *config.GatewaySite) { s.TLS = config.TLSModeNone },
+		"AppName":              func(s *config.GatewaySite) { s.AppName = "Z" },
+		"StripFrameBlockers":   func(s *config.GatewaySite) { s.StripFrameBlockers = false },
+		"Streaming":            func(s *config.GatewaySite) { s.Streaming = false },
+		"BackendSkipTLSVerify": func(s *config.GatewaySite) { s.BackendSkipTLSVerify = false },
+		"RequireAuth":          func(s *config.GatewaySite) { s.RequireAuth = false },
+		"MinRole":              func(s *config.GatewaySite) { s.MinRole = "user" },
+		"ForwardedHeaders":     func(s *config.GatewaySite) { tv := true; s.ForwardedHeaders = &tv },
+		"AllowedGroups":        func(s *config.GatewaySite) { s.AllowedGroups = []string{"other"} },
 	}
 	for name, mut := range mutators {
 		mod := base

--- a/internal/discovery/labels.go
+++ b/internal/discovery/labels.go
@@ -48,6 +48,7 @@ const (
 	LabelGatewayStreaming          = "muximux.gateway.streaming"            // "true" to disable Caddy response buffering
 	LabelGatewayStripFrameBlockers = "muximux.gateway.strip_frame_blockers" // "true" to drop X-Frame-Options on responses
 	LabelGatewayForwardedHeaders   = "muximux.gateway.forwarded_headers"    // "true" to forward X-Forwarded-* headers
+	LabelGatewaySkipTLSVerify      = "muximux.gateway.skip_tls_verify"      // "true" to skip verifying a self-signed HTTPS backend
 	LabelGatewayRequireAuth        = "muximux.gateway.require_auth"         // "true" to gate the site behind Muximux login
 	LabelGatewayMinRole            = "muximux.gateway.min_role"             // user | power-user | admin
 	LabelGatewayAllowedGroups      = "muximux.gateway.allowed_groups"       // comma-separated
@@ -98,6 +99,7 @@ type GatewayLabels struct {
 	Streaming          *bool
 	StripFrameBlockers *bool
 	ForwardedHeaders   *bool
+	SkipTLSVerify      *bool
 	RequireAuth        *bool
 	MinRole            string
 	AllowedGroups      []string
@@ -238,6 +240,7 @@ var gatewayLabelHandlers = map[string]func(out *GatewayLabels, v string){
 	LabelGatewayStreaming:          func(out *GatewayLabels, v string) { b := boolish(v); out.Streaming = &b },
 	LabelGatewayStripFrameBlockers: func(out *GatewayLabels, v string) { b := boolish(v); out.StripFrameBlockers = &b },
 	LabelGatewayForwardedHeaders:   func(out *GatewayLabels, v string) { b := boolish(v); out.ForwardedHeaders = &b },
+	LabelGatewaySkipTLSVerify:      func(out *GatewayLabels, v string) { b := boolish(v); out.SkipTLSVerify = &b },
 	LabelGatewayRequireAuth:        func(out *GatewayLabels, v string) { b := boolish(v); out.RequireAuth = &b },
 	LabelGatewayMinRole: func(out *GatewayLabels, v string) {
 		lv := strings.ToLower(strings.TrimSpace(v))

--- a/internal/discovery/labels_test.go
+++ b/internal/discovery/labels_test.go
@@ -142,6 +142,7 @@ func TestParseGatewayLabels(t *testing.T) {
 			"muximux.gateway.streaming":            "true",
 			"muximux.gateway.strip_frame_blockers": "true",
 			"muximux.gateway.forwarded_headers":    "false",
+			"muximux.gateway.skip_tls_verify":      "true",
 			"muximux.gateway.require_auth":         "true",
 			"muximux.gateway.min_role":             "admin",
 			"muximux.gateway.allowed_groups":       "admins",
@@ -158,6 +159,9 @@ func TestParseGatewayLabels(t *testing.T) {
 		}
 		if got.ForwardedHeaders == nil || *got.ForwardedHeaders {
 			t.Errorf("ForwardedHeaders should be pointer-to-false, got %v", got.ForwardedHeaders)
+		}
+		if got.SkipTLSVerify == nil || !*got.SkipTLSVerify {
+			t.Errorf("SkipTLSVerify = %v", got.SkipTLSVerify)
 		}
 		if got.RequireAuth == nil || !*got.RequireAuth {
 			t.Errorf("RequireAuth = %v", got.RequireAuth)

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -287,18 +287,18 @@ func (p *Poller) tick(ctx context.Context) {
 
 	// Auto-import reconcile. Scan the daemon for labeled containers, map
 	// each Suggestion to its Desired config, diff against the current
-	// apps, and fold the resulting plan into the SAME batch so the
-	// refresh and the auto-import commit atomically (one SaveConfig, one
-	// rollback) in applyRefreshBatch below.
+	// apps AND gateway sites, and fold the resulting plan into the SAME
+	// batch so the refresh and the auto-import commit atomically (one
+	// SaveConfig, one rollback) in applyRefreshBatch below.
 	//
-	// Known, deliberate limitation (approved design): Reconcile's Update
-	// only detects APP-field changes. gateway.domain / gateway.tls change
-	// App.URL so they DO propagate. But a change to a gateway-ONLY field
-	// (require_auth, min_role, streaming, strip_frame_blockers,
-	// forwarded_headers) that leaves every app field unchanged will NOT
-	// trigger an Update, so that site-field change does not propagate
-	// until the container is removed and re-added. We intentionally do
-	// NOT gateway-site field-diff here; update mode re-syncs app fields.
+	// Reconcile's Update fires when either an app field OR a label-derived
+	// gateway-site field differs, so gateway-only labels (require_auth,
+	// min_role, allowed_groups, streaming, strip_frame_blockers,
+	// forwarded_headers, skip_tls_verify) propagate on the next tick even
+	// when no app field changed. Dropping the gateway.domain label reverts
+	// the app to its container URL and drops the orphaned site
+	// (applyReconcile). currentSites is the snapshot Reconcile diffs the
+	// desired sites against.
 	//
 	// Overlap note: for a non-gateway auto app whose container IP changed
 	// with no label change, the URL-refresh pass above and Reconcile's
@@ -721,6 +721,13 @@ func (p *Poller) applyReconcile(batch *refreshBatch) bool {
 	// that carries no desired site (its gateway domain label was removed)
 	// leaves a stale site behind, since the update loop above only
 	// replaces or inserts. Reconcile it away by DockerKey.
+	//
+	// This relies on an invariant: dropping the gateway.domain label
+	// always changes App.URL (public domain -> container URL), so the
+	// entry is always present in updateApps whenever its site must be
+	// orphaned. sameManagedFields compares URL, so the Update is
+	// guaranteed. If that ever stops holding, a dropped site could be
+	// stranded here.
 	if len(batch.updateApps) > 0 {
 		updatedKeys := make(map[string]bool, len(batch.updateApps))
 		for i := range batch.updateApps {

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -171,11 +171,14 @@ func (p *Poller) tick(ctx context.Context) {
 	autoImport := config.NormalizeAutoImport(p.deps.Config.Discovery.Docker.AutoImport)
 	dashboardDomain := p.deps.Config.Server.TLS.Domain
 	tracked := p.collectTracked()
-	// Snapshot the current apps for the reconcile diff while we hold the
-	// read lock. Only needed when auto-import is active.
+	// Snapshot the current apps and gateway sites for the reconcile diff
+	// while we hold the read lock. Sites are needed so a gateway-only
+	// label change is detected. Only relevant when auto-import is active.
 	var currentApps []config.AppConfig
+	var currentSites []config.GatewaySite
 	if autoImport != config.AutoImportOff {
 		currentApps = append([]config.AppConfig(nil), p.deps.Config.Apps...)
+		currentSites = append([]config.GatewaySite(nil), p.deps.Config.Server.GatewaySites...)
 	}
 	p.deps.ConfigMu.RUnlock()
 
@@ -308,7 +311,7 @@ func (p *Poller) tick(ctx context.Context) {
 		for i := range scan.Suggestions {
 			desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
 		}
-		plan := Reconcile(autoImport, desired, currentApps)
+		plan := Reconcile(autoImport, desired, currentApps, currentSites)
 		for i := range plan.Add {
 			batch.addApps = append(batch.addApps, plan.Add[i].App)
 			if plan.Add[i].Site != nil {
@@ -712,6 +715,33 @@ func (p *Poller) applyReconcile(batch *refreshBatch) bool {
 			cfg.Server.GatewaySites = append(cfg.Server.GatewaySites, ns)
 		}
 		touchedGateway = true
+	}
+
+	// Drop orphaned sites: an updated entry whose app was replaced but
+	// that carries no desired site (its gateway domain label was removed)
+	// leaves a stale site behind, since the update loop above only
+	// replaces or inserts. Reconcile it away by DockerKey.
+	if len(batch.updateApps) > 0 {
+		updatedKeys := make(map[string]bool, len(batch.updateApps))
+		for i := range batch.updateApps {
+			if batch.updateApps[i].DockerKey != "" {
+				updatedKeys[batch.updateApps[i].DockerKey] = true
+			}
+		}
+		keptSiteKeys := make(map[string]bool, len(batch.updateSites))
+		for i := range batch.updateSites {
+			keptSiteKeys[batch.updateSites[i].DockerKey] = true
+		}
+		keptSites := cfg.Server.GatewaySites[:0]
+		for i := range cfg.Server.GatewaySites {
+			k := cfg.Server.GatewaySites[i].DockerKey
+			if k != "" && updatedKeys[k] && !keptSiteKeys[k] {
+				touchedGateway = true
+				continue // gateway domain was dropped from this entry
+			}
+			keptSites = append(keptSites, cfg.Server.GatewaySites[i])
+		}
+		cfg.Server.GatewaySites = keptSites
 	}
 
 	// Additions.

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1561,6 +1561,85 @@ func TestTick_AutoImportUpdate_InsertsGatewaySiteWhenLabelAdded(t *testing.T) {
 	}
 }
 
+// TestTick_AutoImportUpdate_GatewayOnlyLabelChangePropagates is #1's core
+// case: a gateway app is imported, then a gateway-only label
+// (require_auth) is added with no app-field change. Update mode must
+// still re-sync the site, proving the site diff (not just the app diff)
+// drives the update.
+func TestTick_AutoImportUpdate_GatewayOnlyLabelChangePropagates(t *testing.T) {
+	set := []ContainerSummary{gwSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	pxy := newProxyForBatchTest([]proxy.GatewaySite{}, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { return nil },
+	})
+
+	p.tick(context.Background())
+	if s := findSiteByKey(cfg, "label:sonarr-auto"); s == nil || s.RequireAuth {
+		t.Fatalf("precondition: imported site must start without require_auth: %+v", s)
+	}
+	appBefore := findAppByKey(cfg, "label:sonarr-auto")
+
+	// Add a gateway-only label; no app field changes.
+	cfg.Discovery.Docker.AutoImport = config.AutoImportUpdate
+	set[0].Labels[LabelGatewayRequireAuth] = "true"
+	p.tick(context.Background())
+
+	site := findSiteByKey(cfg, "label:sonarr-auto")
+	if site == nil || !site.RequireAuth {
+		t.Fatalf("gateway-only label change must propagate to the site: %+v", site)
+	}
+	if a := findAppByKey(cfg, "label:sonarr-auto"); a == nil || a.URL != appBefore.URL {
+		t.Errorf("app URL must be unchanged by a gateway-only label: before=%q after=%+v", appBefore.URL, a)
+	}
+}
+
+// TestTick_AutoImportUpdate_GatewayDomainDroppedRemovesSite: removing the
+// gateway-domain label from a tracked container reverts its app to the
+// direct container URL and drops the now-orphaned gateway site.
+func TestTick_AutoImportUpdate_GatewayDomainDroppedRemovesSite(t *testing.T) {
+	set := []ContainerSummary{gwSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	pxy := newProxyForBatchTest([]proxy.GatewaySite{}, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { return nil },
+	})
+
+	p.tick(context.Background())
+	site := findSiteByKey(cfg, "label:sonarr-auto")
+	if site == nil {
+		t.Fatalf("precondition: gateway site must import")
+	}
+	backend := site.BackendURL // the direct container URL the app should revert to
+
+	cfg.Discovery.Docker.AutoImport = config.AutoImportUpdate
+	delete(set[0].Labels, LabelAppGatewayDomain)
+	delete(set[0].Labels, LabelGatewayTLS)
+	p.tick(context.Background())
+
+	app := findAppByKey(cfg, "label:sonarr-auto")
+	if app == nil || app.URL != backend {
+		t.Fatalf("app should revert to its direct container URL %q: %+v", backend, app)
+	}
+	if s := findSiteByKey(cfg, "label:sonarr-auto"); s != nil {
+		t.Fatalf("orphaned gateway site must be removed: %+v", s)
+	}
+}
+
 func TestTick_AutoImportRollbackOnSaveFailure(t *testing.T) {
 	set := []ContainerSummary{labeledSonarr()}
 	socket, cleanup := mutableDaemonForPoller(t, &set)

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1585,7 +1585,10 @@ func TestTick_AutoImportUpdate_GatewayOnlyLabelChangePropagates(t *testing.T) {
 	if s := findSiteByKey(cfg, "label:sonarr-auto"); s == nil || s.RequireAuth {
 		t.Fatalf("precondition: imported site must start without require_auth: %+v", s)
 	}
-	appBefore := findAppByKey(cfg, "label:sonarr-auto")
+	// Capture by value: findAppByKey returns a pointer into cfg.Apps,
+	// which the tick overwrites in place, so a captured pointer would
+	// alias the post-update URL and make the assertion vacuous.
+	appBeforeURL := findAppByKey(cfg, "label:sonarr-auto").URL
 
 	// Add a gateway-only label; no app field changes.
 	cfg.Discovery.Docker.AutoImport = config.AutoImportUpdate
@@ -1596,8 +1599,8 @@ func TestTick_AutoImportUpdate_GatewayOnlyLabelChangePropagates(t *testing.T) {
 	if site == nil || !site.RequireAuth {
 		t.Fatalf("gateway-only label change must propagate to the site: %+v", site)
 	}
-	if a := findAppByKey(cfg, "label:sonarr-auto"); a == nil || a.URL != appBefore.URL {
-		t.Errorf("app URL must be unchanged by a gateway-only label: before=%q after=%+v", appBefore.URL, a)
+	if a := findAppByKey(cfg, "label:sonarr-auto"); a == nil || a.URL != appBeforeURL {
+		t.Errorf("app URL must be unchanged by a gateway-only label: before=%q after=%+v", appBeforeURL, a)
 	}
 }
 

--- a/internal/discovery/suggest.go
+++ b/internal/discovery/suggest.go
@@ -91,6 +91,7 @@ type SuggestedGatewayConfig struct {
 	Streaming          *bool    `json:"streaming,omitempty"`
 	StripFrameBlockers *bool    `json:"strip_frame_blockers,omitempty"`
 	ForwardedHeaders   *bool    `json:"forwarded_headers,omitempty"`
+	SkipTLSVerify      *bool    `json:"skip_tls_verify,omitempty"`
 	RequireAuth        *bool    `json:"require_auth,omitempty"`
 	MinRole            string   `json:"min_role,omitempty"`
 	AllowedGroups      []string `json:"allowed_groups,omitempty"`
@@ -319,6 +320,7 @@ func attachGatewayLabels(s *Suggestion, containerLabels map[string]string) {
 		Streaming:          gw.Streaming,
 		StripFrameBlockers: gw.StripFrameBlockers,
 		ForwardedHeaders:   gw.ForwardedHeaders,
+		SkipTLSVerify:      gw.SkipTLSVerify,
 		RequireAuth:        gw.RequireAuth,
 		MinRole:            gw.MinRole,
 		AllowedGroups:      gw.AllowedGroups,
@@ -339,7 +341,7 @@ func surfaceUnknownLabels(s *Suggestion, labels *AppLabels) {
 // by value (gocritic hugeParam).
 func gatewayLabelsNonEmpty(g *GatewayLabels) bool {
 	return g.TLS != "" || g.Streaming != nil || g.StripFrameBlockers != nil ||
-		g.ForwardedHeaders != nil || g.RequireAuth != nil ||
+		g.ForwardedHeaders != nil || g.SkipTLSVerify != nil || g.RequireAuth != nil ||
 		g.MinRole != "" || len(g.AllowedGroups) > 0
 }
 

--- a/internal/handlers/reverse_proxy_bundle_test.go
+++ b/internal/handlers/reverse_proxy_bundle_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRewriteScriptKeepsRealBundlesValid is a corpus regression guard for
+// the #371 class of bug: an unanchored rewrite pattern that false-matches
+// inside a minified JS string/regex literal and turns valid JavaScript
+// into a syntax error. It runs every real minified bundle it can find
+// (dependency *.min.js plus Muximux's own built chunks) through
+// rewriteScript and asserts that anything valid before the rewrite is
+// still valid after it, in the same parse goal (module or script).
+//
+// It is a best-effort guard: it skips cleanly when node is not on PATH or
+// when no corpus is present (e.g. a pure-Go CI job with no installed
+// node_modules and no built frontend), so it never fails spuriously. It
+// complements the deterministic, node-free assertions in
+// TestRewriteScriptPreservesJSStringLiterals and TestRewriteModuleImports.
+func TestRewriteScriptKeepsRealBundlesValid(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not on PATH; skipping real-bundle corpus check")
+	}
+
+	var corpus []string
+	for _, root := range []string{"../../web/node_modules", "../server/dist/assets"} {
+		_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil //nolint:nilerr // intentional: per-entry skip, not a propagated failure
+			}
+			if strings.HasSuffix(p, ".min.js") ||
+				(strings.Contains(filepath.ToSlash(p), "/dist/assets/") && strings.HasSuffix(p, ".js")) {
+				corpus = append(corpus, p)
+			}
+			return nil
+		})
+	}
+	if len(corpus) == 0 {
+		t.Skip("no minified-bundle corpus available; skipping")
+	}
+	t.Logf("checking %d real bundles", len(corpus))
+
+	tmp := t.TempDir()
+	// node infers the parse goal from the file extension: .mjs = module,
+	// .cjs = script. A bundle is "valid" in a mode if node --check passes.
+	valid := func(mode string, src []byte) bool {
+		ext := ".cjs"
+		if mode == "module" {
+			ext = ".mjs"
+		}
+		f := filepath.Join(tmp, "chk"+ext)
+		if err := os.WriteFile(f, src, 0o600); err != nil { //nolint:gosec // f is filepath.Join(t.TempDir(), constant); no user-tainted path
+			t.Fatal(err)
+		}
+		return exec.Command("node", "--check", f).Run() == nil //nolint:gosec // fixed args; f is a controlled temp path
+	}
+
+	// Two representative deployments: the common same-host/no-subpath
+	// case, and a subpath+host case that additionally exercises the
+	// target-path and absolute-URL patterns.
+	configs := []struct{ prefix, targetPath, targetHost string }{
+		{"/proxy/app", "", ""},
+		{"/proxy/app", "/app", "192.0.2.10"},
+	}
+
+	for _, file := range corpus {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			continue
+		}
+		okModule, okScript := valid("module", src), valid("script", src)
+		if !okModule && !okScript {
+			continue // not something node can parse; not our concern
+		}
+		for _, c := range configs {
+			out := newContentRewriter(c.prefix, c.targetPath, c.targetHost).rewriteScript(src)
+			if okModule && !valid("module", out) {
+				t.Errorf("%s: valid ES module became invalid after rewriteScript (prefix=%q path=%q host=%q)",
+					file, c.prefix, c.targetPath, c.targetHost)
+			}
+			if okScript && !valid("script", out) {
+				t.Errorf("%s: valid script became invalid after rewriteScript (prefix=%q path=%q host=%q)",
+					file, c.prefix, c.targetPath, c.targetHost)
+			}
+		}
+	}
+}

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -2724,6 +2724,28 @@ func TestRewriteScriptPreservesJSStringLiterals(t *testing.T) {
 			input:    `b.integrity=b.sriHashes[c],b.sriHashes={x:"y"}`,
 			expected: `b.sriHashes={}`,
 		},
+		{
+			// A regex literal that mentions import(...) must not be
+			// touched: no quoted absolute-path specifier is present.
+			name:     "regex literal referencing import is preserved",
+			input:    `var re=/import\(["']\/[^"']+["']\)/g;`,
+			expected: `var re=/import\(["']\/[^"']+["']\)/g;`,
+		},
+		{
+			// Dynamic import with a non-literal (concatenated) argument
+			// is not a static specifier and must be left alone.
+			name:     "dynamic import with non-literal arg is preserved",
+			input:    `import("/"+name)`,
+			expected: `import("/"+name)`,
+		},
+		{
+			// The urlBase heuristic must skip member/qualified names: the
+			// identifier-boundary guard means `x.baseUrl=""` is not an
+			// app-base-path config and stays untouched.
+			name:     "member-access baseUrl is not treated as base config",
+			input:    `obj.baseUrl="";other.baseUrl="x"`,
+			expected: `obj.baseUrl="";other.baseUrl="x"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/proxy/apply_test.go
+++ b/internal/proxy/apply_test.go
@@ -121,19 +121,19 @@ func TestConfigGatewaySitesToProxy_EmptyAndPopulated(t *testing.T) {
 		t.Errorf("empty input -> %v, want nil", got)
 	}
 	in := []config.GatewaySite{
-		{Domain: "a.example.com", BackendURL: "http://10.0.0.1:8080", TLS: config.TLSModeCustom, TLSCert: "/tmp/c", TLSKey: "/tmp/k", StripFrameBlockers: true, Streaming: true},
+		{Domain: "a.example.com", BackendURL: "https://10.0.0.1:8080", TLS: config.TLSModeCustom, TLSCert: "/tmp/c", TLSKey: "/tmp/k", StripFrameBlockers: true, Streaming: true, BackendSkipTLSVerify: true},
 	}
 	out := ConfigGatewaySitesToProxy(in)
 	if len(out) != 1 {
 		t.Fatalf("got %d entries, want 1", len(out))
 	}
-	if out[0].Domain != "a.example.com" || out[0].BackendURL != "http://10.0.0.1:8080" {
+	if out[0].Domain != "a.example.com" || out[0].BackendURL != "https://10.0.0.1:8080" {
 		t.Errorf("domain/backend mismatch: %+v", out[0])
 	}
 	if out[0].TLS != "custom" || out[0].TLSCert != "/tmp/c" || out[0].TLSKey != "/tmp/k" {
 		t.Errorf("tls fields not copied: %+v", out[0])
 	}
-	if !out[0].StripFrameBlockers || !out[0].Streaming {
+	if !out[0].StripFrameBlockers || !out[0].Streaming || !out[0].BackendSkipTLSVerify {
 		t.Errorf("flags not copied: %+v", out[0])
 	}
 }

--- a/internal/proxy/gateway_listen_test.go
+++ b/internal/proxy/gateway_listen_test.go
@@ -201,3 +201,50 @@ func TestBuildCaddyfile_NoRequireAuth_OmitsForwardAuth(t *testing.T) {
 		t.Errorf("forward_auth should not appear when no site has RequireAuth; got:\n%s", out)
 	}
 }
+
+func TestBuildCaddyfile_BackendSkipTLSVerify(t *testing.T) {
+	p := New(&Config{
+		ListenAddr:   ":8080",
+		InternalAddr: "127.0.0.1:18080",
+		GatewaySites: []GatewaySite{
+			// https backend + skip on -> transport block emitted.
+			{Domain: "proxmox.example.com", BackendURL: "https://10.0.0.9:8006", TLS: "auto", BackendSkipTLSVerify: true},
+			// http backend + skip on -> NOT emitted (would force TLS onto plain http).
+			{Domain: "plain.example.com", BackendURL: "http://10.0.0.8:80", TLS: "auto", BackendSkipTLSVerify: true},
+			// https backend + skip off -> NOT emitted (verification stays on).
+			{Domain: "secure.example.com", BackendURL: "https://10.0.0.7:8443", TLS: "auto"},
+		},
+	})
+	out := p.buildCaddyfile()
+
+	proxmox := siteBlock(out, "proxmox.example.com")
+	if !strings.Contains(proxmox, "transport http {") || !strings.Contains(proxmox, "tls_insecure_skip_verify") {
+		t.Errorf("https backend with skip on must emit transport tls_insecure_skip_verify; got:\n%s", proxmox)
+	}
+
+	plain := siteBlock(out, "plain.example.com")
+	if strings.Contains(plain, "tls_insecure_skip_verify") {
+		t.Errorf("http backend must not get tls_insecure_skip_verify (would force TLS); got:\n%s", plain)
+	}
+
+	secure := siteBlock(out, "secure.example.com")
+	if strings.Contains(secure, "tls_insecure_skip_verify") {
+		t.Errorf("https backend with skip off must verify (no skip directive); got:\n%s", secure)
+	}
+}
+
+// siteBlock returns the slice of the Caddyfile from the given domain's
+// selector up to the next site selector, so per-site assertions do not
+// leak across blocks.
+func siteBlock(caddyfile, domain string) string {
+	start := strings.Index(caddyfile, domain)
+	if start < 0 {
+		return ""
+	}
+	rest := caddyfile[start+len(domain):]
+	// Stop at the next ".example.com" selector if any.
+	if next := strings.Index(rest, ".example.com {"); next >= 0 {
+		return rest[:next]
+	}
+	return rest
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -571,8 +571,9 @@ func writeGatewaySiteBlock(b *strings.Builder, s *GatewaySite, gatewayListen, in
 	// (e.g. Proxmox on :8006). Only meaningful over https; enabling the
 	// http transport with tls_insecure_skip_verify implicitly turns on
 	// TLS, so we gate it on an https upstream to avoid forcing TLS onto
-	// a plain-http backend.
-	if s.BackendSkipTLSVerify && strings.HasPrefix(strings.ToLower(s.BackendURL), "https://") {
+	// a plain-http backend. TrimSpace mirrors normalizeUpstream so a
+	// stored URL with incidental whitespace still matches.
+	if s.BackendSkipTLSVerify && strings.HasPrefix(strings.ToLower(strings.TrimSpace(s.BackendURL)), "https://") {
 		b.WriteString("\t\ttransport http {\n")
 		b.WriteString("\t\t\ttls_insecure_skip_verify\n")
 		b.WriteString("\t\t}\n")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -58,8 +58,12 @@ type GatewaySite struct {
 	TLSKey             string
 	StripFrameBlockers bool
 	Streaming          bool
-	ProxyHeaders       map[string]string
-	ForwardedHeaders   *bool
+	// BackendSkipTLSVerify disables backend TLS-certificate
+	// verification (self-signed backends like Proxmox). Only emitted
+	// when BackendURL is https.
+	BackendSkipTLSVerify bool
+	ProxyHeaders         map[string]string
+	ForwardedHeaders     *bool
 	// RequireAuth, when true, makes the generator emit a
 	// forward_auth directive ahead of reverse_proxy that calls
 	// back to Muximux's GatewayAuthHandler on the internal port.
@@ -561,6 +565,17 @@ func writeGatewaySiteBlock(b *strings.Builder, s *GatewaySite, gatewayListen, in
 	// Custom upstream headers (auth tokens, backend API keys).
 	for k, v := range s.ProxyHeaders {
 		fmt.Fprintf(b, "\t\theader_up %s %q\n", k, v)
+	}
+
+	// Backend TLS verification skip for self-signed HTTPS backends
+	// (e.g. Proxmox on :8006). Only meaningful over https; enabling the
+	// http transport with tls_insecure_skip_verify implicitly turns on
+	// TLS, so we gate it on an https upstream to avoid forcing TLS onto
+	// a plain-http backend.
+	if s.BackendSkipTLSVerify && strings.HasPrefix(strings.ToLower(s.BackendURL), "https://") {
+		b.WriteString("\t\ttransport http {\n")
+		b.WriteString("\t\t\ttls_insecure_skip_verify\n")
+		b.WriteString("\t\t}\n")
 	}
 
 	b.WriteString("\t}\n")

--- a/internal/proxy/translate.go
+++ b/internal/proxy/translate.go
@@ -21,16 +21,17 @@ func ConfigGatewaySitesToProxy(sites []config.GatewaySite) []GatewaySite {
 	for i := range sites {
 		s := &sites[i]
 		out[i] = GatewaySite{
-			Domain:             s.Domain,
-			BackendURL:         s.BackendURL,
-			TLS:                string(s.TLS),
-			TLSCert:            s.TLSCert,
-			TLSKey:             s.TLSKey,
-			StripFrameBlockers: s.StripFrameBlockers,
-			Streaming:          s.Streaming,
-			ProxyHeaders:       s.ProxyHeaders,
-			ForwardedHeaders:   s.ForwardedHeaders,
-			RequireAuth:        s.RequireAuth,
+			Domain:               s.Domain,
+			BackendURL:           s.BackendURL,
+			TLS:                  string(s.TLS),
+			TLSCert:              s.TLSCert,
+			TLSKey:               s.TLSKey,
+			StripFrameBlockers:   s.StripFrameBlockers,
+			Streaming:            s.Streaming,
+			BackendSkipTLSVerify: s.BackendSkipTLSVerify,
+			ProxyHeaders:         s.ProxyHeaders,
+			ForwardedHeaders:     s.ForwardedHeaders,
+			RequireAuth:          s.RequireAuth,
 		}
 	}
 	return out

--- a/web/src/components/settings/DiscoverModal.svelte
+++ b/web/src/components/settings/DiscoverModal.svelte
@@ -200,6 +200,7 @@
               if (typeof sg.streaming === 'boolean') gw.streaming = sg.streaming;
               if (typeof sg.strip_frame_blockers === 'boolean') gw.strip_frame_blockers = sg.strip_frame_blockers;
               if (typeof sg.forwarded_headers === 'boolean') gw.forwarded_headers = sg.forwarded_headers;
+              if (typeof sg.skip_tls_verify === 'boolean') gw.backend_skip_tls_verify = sg.skip_tls_verify;
               if (typeof sg.require_auth === 'boolean') gw.require_auth = sg.require_auth;
               if (sg.min_role) gw.min_role = sg.min_role;
               if (sg.allowed_groups && sg.allowed_groups.length > 0) gw.allowed_groups = sg.allowed_groups;

--- a/web/src/components/settings/DiscoverModal.test.ts
+++ b/web/src/components/settings/DiscoverModal.test.ts
@@ -146,6 +146,7 @@ describe('DiscoverModal routing radio + gateway interactions', () => {
         streaming: false,
         strip_frame_blockers: true,
         forwarded_headers: true,
+        skip_tls_verify: true,
         require_auth: true,
         min_role: 'user',
         allowed_groups: ['family'],
@@ -192,6 +193,7 @@ describe('DiscoverModal routing radio + gateway interactions', () => {
     expect(gw.streaming).toBe(false);
     expect(gw.strip_frame_blockers).toBe(true);
     expect(gw.forwarded_headers).toBe(true);
+    expect(gw.backend_skip_tls_verify).toBe(true);
     expect(gw.require_auth).toBe(true);
     expect(gw.min_role).toBe('user');
     expect(gw.allowed_groups).toEqual(['family']);

--- a/web/src/components/settings/GatewayTab.svelte
+++ b/web/src/components/settings/GatewayTab.svelte
@@ -374,6 +374,7 @@
       tls: 'auto',
       strip_frame_blockers: false,
       streaming: false,
+      backend_skip_tls_verify: false,
       forwarded_headers: true,
     };
   }
@@ -710,6 +711,14 @@
             <span>
               <span class="text-text-primary">Forward headers</span>
               <span class="block text-xs text-text-muted">Send X-Forwarded-Proto, X-Forwarded-Host, X-Real-IP. On by default; turn off for backends that reject those headers.</span>
+            </span>
+          </label>
+
+          <label class="flex items-start gap-2 cursor-pointer text-sm" data-testid="gw-skip-tls-verify">
+            <input type="checkbox" bind:checked={form.backend_skip_tls_verify} />
+            <span>
+              <span class="text-text-primary">Skip backend TLS verification</span>
+              <span class="block text-xs text-text-muted">For backends serving a self-signed or untrusted HTTPS certificate (e.g. Proxmox on :8006). Only applies when the backend URL is https; the public-facing certificate is unaffected.</span>
             </span>
           </label>
 

--- a/web/src/components/settings/GatewayTab.test.ts
+++ b/web/src/components/settings/GatewayTab.test.ts
@@ -367,6 +367,21 @@ describe('GatewayTab Require Muximux login (auth gate)', () => {
     expect(arg.allowed_groups).toEqual(['family', 'admins']);
   });
 
+  it('sends backend_skip_tls_verify when the skip-TLS-verify toggle is ticked', async () => {
+    render(GatewayTab);
+    await waitFor(() => expect(screen.getByRole('button', { name: /add gateway site/i })).toBeInTheDocument());
+    await fireEvent.click(screen.getByRole('button', { name: /add gateway site/i }));
+
+    await fireEvent.input(screen.getByLabelText('Domain'), { target: { value: 'proxmox.example.com' } });
+    await fireEvent.input(screen.getByLabelText('Backend URL'), { target: { value: 'https://proxmox:8006' } });
+    const skipVerify = screen.getByTestId('gw-skip-tls-verify').querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await fireEvent.click(skipVerify);
+
+    await fireEvent.click(screen.getByRole('button', { name: /add site/i }));
+    await waitFor(() => expect(mockCreateGatewaySite).toHaveBeenCalledTimes(1));
+    expect(mockCreateGatewaySite.mock.calls[0][0].backend_skip_tls_verify).toBe(true);
+  });
+
   it('omits allowed_groups from the payload when the field is empty (preserves "any user" semantics)', async () => {
     // The validator on the Go side treats an empty allowed_groups as
     // "no group check"; emitting it as an empty array vs. omitting it

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -221,6 +221,10 @@ export interface GatewaySite {
   tls_key?: string;
   strip_frame_blockers?: boolean;
   streaming?: boolean;
+  // Skip verification of a self-signed / untrusted HTTPS backend
+  // certificate (e.g. Proxmox). Only takes effect when backend_url is
+  // https; the public-facing TLS is unaffected.
+  backend_skip_tls_verify?: boolean;
   proxy_headers?: Record<string, string>;
   forwarded_headers?: boolean;
   app_name?: string;
@@ -438,6 +442,7 @@ export interface SuggestedGatewayConfig {
   streaming?: boolean;
   strip_frame_blockers?: boolean;
   forwarded_headers?: boolean;
+  skip_tls_verify?: boolean;
   require_auth?: boolean;
   min_role?: 'user' | 'power-user' | 'admin';
   allowed_groups?: string[];


### PR DESCRIPTION
Implements the top three items from the post-3.2.0 backlog. Three independent gap-fixes, each with tests and docs. Rebased on top of the 3.2.0 doc audit (#380).

## 1. Gateway-only label changes propagate in auto-import `update`/`sync`
The reconciler only diffed **app** fields, so gateway-only labels (`require_auth`, `min_role`, `allowed_groups`, `streaming`, `strip_frame_blockers`, `forwarded_headers`) never re-synced unless an app field also changed -- the documented 3.2.0 limitation. `Reconcile` now also diffs the gateway **site** by `DockerKey`: an auto-imported entry updates when its app fields *or* its label-derived site fields differ. Dropping a container's `gateway.domain` label reverts the app to its direct URL and removes the orphaned site. The site diff excludes `BackendURL` (owned by the URL-refresh pass) so an IP change alone never looks like a label change.

## 2. Gateway backend `backend_skip_tls_verify` for self-signed HTTPS backends
New `GatewaySite.backend_skip_tls_verify` emits Caddy's `transport http { tls_insecure_skip_verify }`, gated on an https backend (enabling the http transport implicitly turns TLS on, so it would wrongly force TLS onto a plain-http backend). Lets the embedded gateway front self-signed backends like Proxmox on `:8006`, which previously needed an external proxy. Wired end to end: config + Caddy generator + `muximux.gateway.skip_tls_verify` discovery label (parsed, carried through auto-import, and diffed by #1) + frontend (type, Discover-modal mapping, Settings -> Gateway toggle).

## 3. Proxy JS-rewriter false-match audit (#371 class)
Ran every real minified bundle available (44 dependency `*.min.js` + Muximux's own built chunks) through `rewriteScript` under two deployment shapes: none that parse as valid JS became invalid, so no surviving #371-class false match that breaks a script. The residual case (import/base text *inside* a string/template literal) stays valid JS and only mis-rewrites a path; distinguishing literal context from code needs a JS tokenizer, and any partial regex guard would risk breaking real imports (which must be rewritten because the module loader bypasses fetch interception). So this locks in current behavior rather than changing it: a node-gated corpus regression test (skips cleanly when node/corpus absent) plus deterministic cases pinning the guards that hold.

## Docs & review
- Docs updated: `docker-discovery.md` (gateway label + rewritten limitation section), `configuration.md` and `gateway-examples.md` (`backend_skip_tls_verify`, incl. a working Proxmox recipe on top of #380's reframed page), CHANGELOG `[Unreleased]`.
- A whole-branch Opus code review ran; its findings (a stale comment and a skip-verify gate that should `TrimSpace`) are folded into the `review:` commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Skip backend TLS verification” gateway-site option (controls only backend certificate verification for HTTPS backends).
  * The setting is supported end-to-end: labels, discovery/import, and the gateway configuration UI.

* **Bug Fixes**
  * Auto-import/update/sync now re-syncs gateway-site changes, including this backend TLS skip flag and other gateway label-driven fields.
  * Dropping a gateway domain now restores the app’s direct URL and removes the orphaned gateway site on the next reconciliation.

* **Documentation / Tests**
  * Updated gateway configuration docs with the new option and scope. Added/extended test coverage for this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
