### PR TITLE
3.2.2: reliability + security hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to Muximux are documented in this file.
 
+## [3.2.2] - 2026-07-02
+
+A reliability and security hotfix. Drop-in: no config changes.
+
+### Security
+- `http_action` no longer follows HTTP redirects. An admin-configured
+  action target could return a redirect to a link-local or loopback
+  address (e.g. `169.254.169.254`, `127.0.0.1`) and drive Muximux into
+  probing internal services -- a server-side request forgery (SSRF)
+  vector. The action's own URL is still requested directly (internal
+  homelab webhooks keep working); only redirect-following is dropped.
+- Deleting a user now revokes their active sessions immediately. Before,
+  a deleted account -- including its captured role -- stayed usable until
+  the session's absolute expiry (up to 7 days), defeating deletion as an
+  access-revocation control.
+
+### Fixed
+- Auto-import in `sync` mode no longer deletes every auto-imported app and
+  gateway site when a Docker scan fails or is blocked (a transient daemon
+  error or a self-detect failure). Reconcile is skipped until the scan
+  succeeds again.
+- Oversized proxied responses are forwarded in full instead of being
+  silently truncated at the 50 MB rewrite limit. A chunked or gzipped
+  response larger than the limit (e.g. a large JSON API payload) was cut
+  to the first 50 MB; the whole stream is now passed through unmodified.
+- Fixed a data race between the discovery poller refreshing an app URL in
+  place and `GET /api/config/export` marshalling the config.
+- `config.Save` removes its temporary file when the final rename fails,
+  instead of leaking a `.config-*.yaml` in the data directory.
+
 ## [3.2.1] - 2026-07-01
 
 A follow-up to 3.2.0's automatic Docker import: auto-import now keeps

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1400,6 +1400,7 @@ func (c *Config) Save(path string) error {
 		return err
 	}
 	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName) // don't leave the temp file behind on a failed rename
 		return err
 	}
 	// fsync the parent directory so the rename hits stable storage

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1777,3 +1777,33 @@ func TestLoadDetachClearsAutoImported(t *testing.T) {
 			app.DockerKey, app.DockerAutoImported)
 	}
 }
+
+// TestSave_RemovesTempFileOnRenameFailure: every Save error path cleans
+// up its temp file except the final rename, which used to leak a
+// .config-*.yaml on failure. Force a rename failure by pointing Save at
+// an existing (non-empty) directory and assert no temp file is left.
+func TestSave_RemovesTempFileOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "config-as-dir")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "keep"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{Apps: []AppConfig{{Name: "a", URL: "http://a"}}}
+	if err := cfg.Save(target); err == nil {
+		t.Fatal("expected Save to fail renaming onto a directory")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".config-") {
+			t.Errorf("temp file leaked after failed rename: %s", e.Name())
+		}
+	}
+}

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -307,24 +307,35 @@ func (p *Poller) tick(ctx context.Context) {
 	// this is not a double-write bug.
 	if autoImport != config.AutoImportOff {
 		scan := svc.Scan(ctx, dashboardDomain)
-		desired := make([]Desired, 0, len(scan.Suggestions))
-		for i := range scan.Suggestions {
-			desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
-		}
-		plan := Reconcile(autoImport, desired, currentApps, currentSites)
-		for i := range plan.Add {
-			batch.addApps = append(batch.addApps, plan.Add[i].App)
-			if plan.Add[i].Site != nil {
-				batch.addSites = append(batch.addSites, *plan.Add[i].Site)
+		// A failed or blocked scan yields no suggestions. Treating that
+		// empty result as the desired set would make sync mode conclude
+		// every labeled container vanished and delete every auto-imported
+		// app + gateway site (data loss on a transient daemon hiccup or a
+		// self-detect failure). Skip reconcile until the scan succeeds
+		// again; the URL-refresh batch built above still commits below.
+		if scan.Error != "" || scan.ScanBlocked != "" {
+			logging.Warn("Discovery auto-import skipped: scan did not complete",
+				"source", "discovery", "error", scan.Error, "blocked", scan.ScanBlocked)
+		} else {
+			desired := make([]Desired, 0, len(scan.Suggestions))
+			for i := range scan.Suggestions {
+				desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
 			}
-		}
-		for i := range plan.Update {
-			batch.updateApps = append(batch.updateApps, plan.Update[i].App)
-			if plan.Update[i].Site != nil {
-				batch.updateSites = append(batch.updateSites, *plan.Update[i].Site)
+			plan := Reconcile(autoImport, desired, currentApps, currentSites)
+			for i := range plan.Add {
+				batch.addApps = append(batch.addApps, plan.Add[i].App)
+				if plan.Add[i].Site != nil {
+					batch.addSites = append(batch.addSites, *plan.Add[i].Site)
+				}
 			}
+			for i := range plan.Update {
+				batch.updateApps = append(batch.updateApps, plan.Update[i].App)
+				if plan.Update[i].Site != nil {
+					batch.updateSites = append(batch.updateSites, *plan.Update[i].Site)
+				}
+			}
+			batch.removeKeys = append(batch.removeKeys, plan.RemoveKeys...)
 		}
-		batch.removeKeys = append(batch.removeKeys, plan.RemoveKeys...)
 	}
 
 	if batch.empty() {

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1477,6 +1477,56 @@ func gwSonarr() ContainerSummary {
 	return c
 }
 
+// TestTick_AutoImportSync_ScanFailureDoesNotDeleteApps is a regression
+// guard for a data-loss bug: in sync mode a failed/blocked scan produced
+// an empty desired set, and Reconcile then treated every auto-imported
+// app as "vanished" and deleted it. A transient daemon hiccup must never
+// wipe the tracked apps. Here the container list succeeds (so the tick
+// proceeds past the URL-refresh pass) but the self-detect scan is blocked
+// (network_filter empty + no self-inspect endpoint served), so
+// svc.Scan() returns ScanBlocked with no suggestions.
+func TestTick_AutoImportSync_ScanFailureDoesNotDeleteApps(t *testing.T) {
+	set := []ContainerSummary{} // container list succeeds but is empty
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportSync)
+	// Empty network_filter forces the self-detect path, which is blocked
+	// in the test env (the fake daemon serves no self-inspect endpoint).
+	dockerCfg.NetworkFilter = ""
+	cfg.Discovery.Docker.NetworkFilter = ""
+	// Pre-existing auto-imported app + its gateway site.
+	cfg.Apps = []config.AppConfig{{
+		Name: "Sonarr", URL: "https://sonarr.example.com",
+		DockerKey: "label:sonarr-auto", DockerAutoImported: true,
+	}}
+	cfg.Server.GatewaySites = []config.GatewaySite{{
+		Domain: "sonarr.example.com", BackendURL: "http://10.0.0.5:8989",
+		DockerKey: "label:sonarr-auto",
+	}}
+	pxy := newProxyForBatchTest([]proxy.GatewaySite{}, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:sonarr-auto") == nil {
+		t.Fatal("scan failure must NOT delete the auto-imported app")
+	}
+	if findSiteByKey(cfg, "label:sonarr-auto") == nil {
+		t.Fatal("scan failure must NOT delete the auto-imported gateway site")
+	}
+	if saveCalls != 0 {
+		t.Errorf("no config change expected on a blocked scan; Save called %d times", saveCalls)
+	}
+}
+
 func TestTick_AutoImportAdd_GatewaySite(t *testing.T) {
 	set := []ContainerSummary{gwSonarr()}
 	socket, cleanup := mutableDaemonForPoller(t, &set)

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -113,13 +113,25 @@ func (h *APIHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 func (h *APIHandler) ExportConfig(w http.ResponseWriter, r *http.Request) {
 	h.mu.RLock()
 	cfg := *h.config
-	h.mu.RUnlock()
-
-	// Deep-copy slices that will be mutated to avoid writing through the
-	// shared backing array into the live config.
+	// Copy the slices we will read during the (unlocked) marshal off the
+	// live backing arrays. The poller and UpdateApp mutate Apps/Groups/
+	// GatewaySites elements in place under the write lock, so marshalling
+	// the shared arrays after RUnlock is a data race. Copying under the
+	// lock is safe (RLock excludes the writer); the marshal then runs on
+	// our private arrays. Users additionally gets its secrets stripped.
 	users := make([]config.UserConfig, len(cfg.Auth.Users))
 	copy(users, cfg.Auth.Users)
 	cfg.Auth.Users = users
+	apps := make([]config.AppConfig, len(cfg.Apps))
+	copy(apps, cfg.Apps)
+	cfg.Apps = apps
+	groups := make([]config.GroupConfig, len(cfg.Groups))
+	copy(groups, cfg.Groups)
+	cfg.Groups = groups
+	sites := make([]config.GatewaySite, len(cfg.Server.GatewaySites))
+	copy(sites, cfg.Server.GatewaySites)
+	cfg.Server.GatewaySites = sites
+	h.mu.RUnlock()
 
 	// Strip sensitive auth data
 	for i := range cfg.Auth.Users {

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -59,10 +59,23 @@ func (h *APIHandler) SetDockerLifecycleDeps(svc DockerServiceAPI, hub DockerHubB
 // NewAPIHandler creates a new API handler
 func NewAPIHandler(cfg *config.Config, configPath string, mu *sync.RWMutex) *APIHandler {
 	return &APIHandler{
-		config:       cfg,
-		configPath:   configPath,
-		mu:           mu,
-		actionClient: &http.Client{Timeout: 10 * time.Second},
+		config:     cfg,
+		configPath: configPath,
+		mu:         mu,
+		actionClient: &http.Client{
+			Timeout: 10 * time.Second,
+			// Do not follow redirects. http_action targets are admin-
+			// configured (a private-IP homelab webhook is legitimate, so
+			// the initial request is intentionally not IP-filtered), but a
+			// redirect Location is controlled by the target server -- an
+			// external target that 302s to a link-local/loopback address
+			// would turn this into a server-side SSRF probe. Returning the
+			// 3xx as-is keeps the direct-hit use case working while closing
+			// the redirect vector.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 	}
 }
 

--- a/internal/handlers/api_test.go
+++ b/internal/handlers/api_test.go
@@ -2852,3 +2852,31 @@ func TestBuildClientConfigResponseWithAuth(t *testing.T) {
 		}
 	})
 }
+
+// TestExportConfig_NoRaceWithConcurrentAppMutation guards the config
+// export against a data race: ExportConfig takes a shallow copy of the
+// config and marshals it after releasing the lock, so the marshal read of
+// cfg.Apps[i] must not alias a slice the poller/UpdateApp mutate in place.
+// Fails under -race unless Apps/Groups/GatewaySites are copied under the
+// lock (like Users already is).
+func TestExportConfig_NoRaceWithConcurrentAppMutation(t *testing.T) {
+	cfg := &config.Config{Apps: []config.AppConfig{{Name: "a", URL: "http://a"}}}
+	var mu sync.RWMutex
+	h := NewAPIHandler(cfg, "", &mu)
+
+	urls := []string{"http://a-0", "http://a-1"}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 2000; i++ {
+			mu.Lock()
+			cfg.Apps[0].URL = urls[i%2]
+			mu.Unlock()
+		}
+		close(done)
+	}()
+	for i := 0; i < 2000; i++ {
+		w := httptest.NewRecorder()
+		h.ExportConfig(w, httptest.NewRequest(http.MethodGet, "/api/config/export", nil))
+	}
+	<-done
+}

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -774,6 +774,16 @@ func (h *AuthHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Revoke the deleted user's live sessions so the account cannot keep
+	// acting (with its captured role) until the session's absolute expiry.
+	// Mirrors ChangePassword. Keyed by user ID (== username for builtin
+	// users). Best-effort: the user is already gone from the store, so a
+	// lingering session would fail the GetByID lookup anyway, but this
+	// closes the userFromSession fallback path immediately.
+	if prev != nil {
+		h.sessionStore.DeleteByUserID(prev.ID, "")
+	}
+
 	logging.From(r.Context()).Info("User deleted", "source", "audit", "user", username)
 	sendJSON(w, http.StatusOK, map[string]bool{"success": true})
 }

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -1054,6 +1054,43 @@ func TestUpdateUser(t *testing.T) {
 	})
 }
 
+// TestDeleteUser_RevokesSessions: deleting a user must invalidate their
+// live sessions. Otherwise the deleted account stays authenticated (and,
+// via userFromSession, keeps its captured role) until the session's
+// 7-day absolute expiry -- defeating deletion as an access-revocation
+// control. ChangePassword already does this; deletion must too.
+func TestDeleteUser_RevokesSessions(t *testing.T) {
+	handler, sessionStore := setupAuthTest(t)
+
+	hash, _ := auth.HashPassword("password123")
+	if err := handler.userStore.Add(&auth.User{
+		ID: "victim", Username: "victim", PasswordHash: hash, Role: "user",
+	}); err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	sess, err := sessionStore.Create("victim", "victim", "user")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if sessionStore.Get(sess.ID) == nil {
+		t.Fatal("precondition: victim session must exist")
+	}
+
+	currentUser := &auth.User{ID: "admin", Username: "admin", Role: "admin"}
+	req := httptest.NewRequest(http.MethodDelete, "/api/auth/users/victim", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ContextKeyUser, currentUser))
+	w := httptest.NewRecorder()
+
+	handler.DeleteUser(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if sessionStore.Get(sess.ID) != nil {
+		t.Error("deleting a user must revoke their active sessions")
+	}
+}
+
 func TestDeleteUser(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		handler, _ := setupAuthTest(t)

--- a/internal/handlers/http_action_test.go
+++ b/internal/handlers/http_action_test.go
@@ -17,6 +17,44 @@ import (
 	"github.com/mescon/muximux/v3/internal/config"
 )
 
+// TestActionClient_DoesNotFollowRedirects: http_action targets are
+// admin-configured (a private-IP homelab webhook is legitimate, so the
+// initial request is not IP-filtered), but the redirect Location is
+// controlled by the target server -- an external target that 302s to
+// 169.254.169.254 or 127.0.0.1 would let it drive internal requests
+// server-side. The client must not follow redirects.
+func TestActionClient_DoesNotFollowRedirects(t *testing.T) {
+	internalHit := false
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		internalHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer internal.Close()
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	h := NewAPIHandler(&config.Config{}, "", &sync.RWMutex{})
+	req, err := http.NewRequest(http.MethodGet, redirector.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := h.actionClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("redirect must not be followed; want 302, got %d", resp.StatusCode)
+	}
+	if internalHit {
+		t.Error("actionClient followed the redirect to the internal target (SSRF)")
+	}
+}
+
 func newFireActionTest(t *testing.T, app *config.AppConfig, upstream http.HandlerFunc) *APIHandler {
 	t.Helper()
 	server := httptest.NewServer(upstream)

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -1404,7 +1404,8 @@ func (r *contentRewriter) injectInterceptor(content []byte, docPath string) []by
 // maxRewriteSize is the maximum response body size (50 MB) that will be buffered
 // for URL rewriting. Text responses larger than this stream through unmodified to
 // avoid excessive memory use. In practice, HTML/CSS/JS are rarely this large.
-const maxRewriteSize = 50 * 1024 * 1024
+// A var (not const) only so tests can lower it without allocating 50 MB.
+var maxRewriteSize int64 = 50 * 1024 * 1024
 
 // maxPooledBodyBufSize caps which read buffers go back into the
 // pool. Without this, a single oversized response (e.g. a big
@@ -1440,11 +1441,19 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 		return nil
 	}
 
-	var reader io.Reader = resp.Body
+	orig := resp.Body
+	var reader io.Reader = orig
 	isGzipped := strings.Contains(resp.Header.Get(headerContentEncoding), "gzip")
 
+	// When gzipped, tee the compressed bytes as we decompress. If the
+	// decompressed body turns out to exceed the rewrite limit we forward
+	// the ORIGINAL compressed stream verbatim: the compressed bytes the
+	// gzip reader already consumed live in compressedSeen, the rest stays
+	// unread in orig, and the two concatenate to the exact original stream.
+	var compressedSeen *bytes.Buffer
 	if isGzipped {
-		gzReader, err := gzip.NewReader(resp.Body)
+		compressedSeen = &bytes.Buffer{}
+		gzReader, err := gzip.NewReader(io.TeeReader(orig, compressedSeen))
 		if err != nil {
 			// Surface decode failures so ReverseProxy's ErrorHandler can
 			// return a clean 502 rather than forwarding a partially-
@@ -1464,14 +1473,14 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 	// Read upstream body into a pooled buffer. The rewriter produces
 	// an independent []byte (every rewrite path allocates fresh), so
 	// once we've finished rewriting we can release the buffer back
-	// to the pool without aliasing risk.
+	// to the pool without aliasing risk. orig is NOT closed yet: on the
+	// over-limit path below we still need to forward its unread remainder.
 	buf := bodyReadBufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	if _, err := buf.ReadFrom(limited); err != nil {
 		bodyReadBufPool.Put(buf)
 		return fmt.Errorf("proxy: read body: %w", err)
 	}
-	resp.Body.Close()
 	body := buf.Bytes()
 
 	// releaseBuf returns the read buffer to the pool when safe.
@@ -1484,20 +1493,32 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 		}
 	}
 
-	// Safety net for chunked responses without Content-Length: if the body
-	// exceeds the rewrite limit, return it unmodified rather than rewriting.
+	// Over the rewrite limit (chunked/gzipped responses whose full size
+	// isn't known up front from Content-Length). Forward the WHOLE
+	// original stream unmodified rather than truncating it to the first
+	// maxRewriteSize bytes. The prefix already read is spliced back in
+	// front of orig's unread remainder; headers (Content-Encoding,
+	// Content-Length) are left untouched so the framing stays valid.
 	if int64(len(body)) > maxRewriteSize {
-		// body aliases the pooled buffer; copy out before releasing
-		// so the response keeps a stable backing array.
-		bodyCopy := make([]byte, len(body))
-		copy(bodyCopy, body)
+		var prefix []byte
+		if isGzipped {
+			prefix = make([]byte, compressedSeen.Len())
+			copy(prefix, compressedSeen.Bytes())
+		} else {
+			prefix = make([]byte, len(body))
+			copy(prefix, body)
+		}
 		releaseBuf()
-		resp.Body = io.NopCloser(bytes.NewReader(bodyCopy))
-		resp.ContentLength = int64(len(bodyCopy))
-		resp.Header.Set("Content-Length", strconv.Itoa(len(bodyCopy)))
-		resp.Header.Del(headerContentEncoding)
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{io.MultiReader(bytes.NewReader(prefix), orig), orig}
 		return nil
 	}
+
+	// Under the limit: the buffer holds the entire body, so the original
+	// upstream reader can be closed now.
+	orig.Close()
 
 	lowerContentType := strings.ToLower(contentType)
 	isHTML := strings.Contains(lowerContentType, "text/html")

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -3729,3 +3729,74 @@ func TestBuildUpgradeRequest_StripsCookieAndInjectsHeaders(t *testing.T) {
 		t.Errorf("expected request line + Host, got:\n%s", out)
 	}
 }
+
+// TestRewriteResponseBody_OverLimitForwardsFullStream: a chunked response
+// (unknown Content-Length) larger than the rewrite limit must be
+// forwarded in full, not truncated to the first maxRewriteSize bytes.
+func TestRewriteResponseBody_OverLimitForwardsFullStream(t *testing.T) {
+	old := maxRewriteSize
+	maxRewriteSize = 1024
+	defer func() { maxRewriteSize = old }()
+
+	rewriter := newContentRewriter("/proxy/app", "", "")
+	body := "<html>" + strings.Repeat("x", 4096) + `<a href="/foo">` + strings.Repeat("y", 4096) + "</html>"
+	if int64(len(body)) <= maxRewriteSize {
+		t.Fatal("test body must exceed the lowered limit")
+	}
+	resp := &http.Response{
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: -1, // chunked / unknown length
+	}
+	resp.Header.Set("Content-Type", "text/html")
+
+	if err := rewriteResponseBody(resp, rewriter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("over-limit body must be forwarded in full and unmodified: got %d bytes, want %d", len(got), len(body))
+	}
+}
+
+// TestRewriteResponseBody_OverLimitGzipForwardsCompressed: a gzipped
+// response whose DECOMPRESSED size exceeds the limit (but whose compressed
+// size is under it, so it isn't fast-path skipped) must forward the
+// original compressed stream verbatim, keeping Content-Encoding: gzip.
+func TestRewriteResponseBody_OverLimitGzipForwardsCompressed(t *testing.T) {
+	old := maxRewriteSize
+	maxRewriteSize = 1024
+	defer func() { maxRewriteSize = old }()
+
+	rewriter := newContentRewriter("/proxy/app", "", "")
+	plain := "<html>" + strings.Repeat("z", 8192) + "</html>" // decompresses > limit
+	var gzbuf bytes.Buffer
+	gw := gzip.NewWriter(&gzbuf)
+	if _, err := gw.Write([]byte(plain)); err != nil {
+		t.Fatal(err)
+	}
+	gw.Close()
+	compressed := gzbuf.Bytes()
+	if int64(len(compressed)) > maxRewriteSize {
+		t.Fatal("compressed body must be under the limit so it is not fast-path skipped")
+	}
+
+	resp := &http.Response{
+		Header:        make(http.Header),
+		Body:          io.NopCloser(bytes.NewReader(compressed)),
+		ContentLength: int64(len(compressed)),
+	}
+	resp.Header.Set("Content-Type", "text/html")
+	resp.Header.Set("Content-Encoding", "gzip")
+
+	if err := rewriteResponseBody(resp, rewriter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(got, compressed) {
+		t.Errorf("over-limit gzip must forward the original compressed stream: got %d bytes, want %d", len(got), len(compressed))
+	}
+	if resp.Header.Get("Content-Encoding") != "gzip" {
+		t.Errorf("Content-Encoding must remain gzip, got %q", resp.Header.Get("Content-Encoding"))
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1108,7 +1108,9 @@ func TestRegisterAPIRoutes(t *testing.T) {
 			{Name: "Group1", Color: "#ff0000"},
 		},
 	}
-	api := handlers.NewAPIHandler(cfg, "", &sync.RWMutex{})
+	// Real temp config path so SaveConfig writes into t.TempDir() instead
+	// of failing a rename in the package dir (which leaked .config-*.yaml).
+	api := handlers.NewAPIHandler(cfg, filepath.Join(t.TempDir(), "config.yaml"), &sync.RWMutex{})
 
 	noopAdmin := adminGuard(func(next http.HandlerFunc) http.HandlerFunc {
 		return next
@@ -1410,7 +1412,9 @@ func TestRoutes_DockerLifecycle_Registered(t *testing.T) {
 			{Name: "sonarr", URL: "http://a:8080", Enabled: true},
 		},
 	}
-	api := handlers.NewAPIHandler(cfg, "", &sync.RWMutex{})
+	// Real temp config path so SaveConfig writes into t.TempDir() instead
+	// of failing a rename in the package dir (which leaked .config-*.yaml).
+	api := handlers.NewAPIHandler(cfg, filepath.Join(t.TempDir(), "config.yaml"), &sync.RWMutex{})
 
 	noopAdmin := adminGuard(func(next http.HandlerFunc) http.HandlerFunc {
 		return next


### PR DESCRIPTION
A focused hotfix batch from a full-codebase review. Drop-in; no config changes. Each fix is TDD (failing test first) and the batch passed an adversarial review pass.

## Security
- **http_action SSRF** — the action client followed HTTP redirects with no guard, so an admin-configured target could 302 Muximux into probing link-local/loopback addresses. Redirect-following is dropped (the configured URL is still requested directly, so internal homelab webhooks keep working).
- **Session revocation on user delete** — deleting a user now invalidates their live sessions immediately, instead of leaving the account (and its captured role) usable until the 7-day absolute expiry.

## Fixed
- **Data loss in `sync` auto-import** — a failed or blocked Docker scan produced an empty desired set, so sync mode deleted every auto-imported app + gateway site. Reconcile is now skipped until the scan succeeds again.
- **Response truncation** — chunked/gzipped proxied responses larger than the 50 MB rewrite limit were silently cut to 50 MB; the full stream is now forwarded unmodified (gzip forwarded verbatim, Content-Encoding preserved).
- **Config-export data race** — the poller refreshing an app URL in place raced `GET /api/config/export` marshalling the config; the export now copies the slices under the lock.
- **Temp-file leak** — `config.Save` now removes its temp file when the final rename fails (also cleaned up 1841 leaked test artifacts).

Verified: full Go suite incl. `-race`, golangci-lint, gofmt. CHANGELOG entry for 3.2.2 included; **not tagged/released** — merge at your discretion, release later.

Follow-on reliability work (discovery robustness, identity-forwarding #388, proxy fixes) is on a separate branch and will come as a later PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection against redirect-based internal network access.
  * User deletion now immediately revokes active sessions.

* **Bug Fixes**
  * Auto-import no longer removes apps when discovery scans fail or are blocked.
  * Large proxied responses now pass through correctly instead of being truncated.
  * Config exports are more reliable during concurrent updates.
  * Failed config saves now clean up temporary files properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->