### PR TITLE
3.2.2: security posture + proxy reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,104 +2,81 @@
 
 All notable changes to Muximux are documented in this file.
 
-## [3.3.0] - 2026-07-02
+## [3.2.2] - 2026-07-03
 
-A broad reliability, security, and accessibility pass across the whole
-stack -- the reverse proxy, Docker discovery, auth, config persistence, and
-the frontend. One new feature (identity forwarding to proxied backends);
-everything else hardens behaviour you already rely on. Drop-in: no config
-changes required.
+A security-focused release. It hardens authentication, the reverse proxy,
+and file uploads, and fixes several cases where a proxied backend rendered
+incorrectly through Muximux. One small new capability -- identity forwarding
+to proxied backends. Drop-in: no config changes required, and existing API
+keys migrate themselves.
 
 ### Added
-- **Forward the signed-in user's identity to proxied backends.** Custom
-  proxy headers now expand `${user}`, `${role}`, `${email}`,
-  `${display_name}`, and `${groups}` to the current user's values, so a
-  backend behind Muximux can trust the dashboard's authentication instead
-  of running its own login. Values are stripped of CR/LF/NUL before being
-  sent. Documented in the reverse-proxy wiki page.
+- **Forward the signed-in user's identity to proxied backends.** A custom
+  proxy header value can now include `${user}`, `${role}`, `${email}`,
+  `${display_name}`, or `${groups}`, and Muximux substitutes the current
+  user's values before forwarding the request. A backend behind Muximux can
+  use this to trust the dashboard's login instead of running its own. Opt-in:
+  only headers you configure with these placeholders are affected. See the
+  reverse-proxy wiki page.
+
+### Changed (behaviour worth noting)
+- **Built-in users are now accepted at gateway sites with a group
+  allowlist.** A gateway site with `allowed_groups` previously admitted only
+  OIDC users; a built-in user's group memberships are now honoured too. If
+  you use `allowed_groups`, built-in users in those groups will start getting
+  access.
+- **Docker start/stop/restart now respect per-app visibility.** A user who
+  cannot see an app (because of its `min_role` or `allowed_groups`) can no
+  longer start, stop, or restart its container.
+- **`http_action` no longer follows HTTP redirects.** If you configured an
+  action whose endpoint responded with a redirect, only the original URL is
+  now requested (this closes a server-side request forgery vector). Direct
+  webhook targets are unaffected.
+- **The app add/edit dialogs are now keyboard-accessible** -- focus is moved
+  into the dialog and trapped while it is open, restored on close, and
+  Escape closes it.
+- **The Docker start/stop/restart confirmation shows progress** and stays
+  open until the action finishes, instead of closing immediately.
 
 ### Security
-- **API keys are hashed with SHA-256 instead of bcrypt.** Verifying an
-  attacker-supplied `X-Api-Key` ran bcrypt before authentication on every
-  request -- an unauthenticated CPU-amplification (DoS) vector. API keys
-  are high-entropy tokens, so a fast constant-time hash is equally
-  brute-force-resistant. Existing bcrypt hashes keep working and are
-  auto-upgraded to the new form on first successful use (no manual key
-  rotation needed).
-- **Uploaded icons are type-checked by their bytes, not the client's
-  Content-Type.** A crafted upload could claim `image/svg+xml` while
-  carrying HTML/JS and be served back with that type -- stored XSS on the
-  dashboard origin. Uploads are now sniffed and an SVG claim is honoured
-  only when the bytes actually look like SVG.
-- **The remote changelog is sanitized before rendering.** The About tab
-  rendered update-check release notes through a markdown parser and
-  `{@html}`; the content is now run through DOMPurify first, stripping
-  scripts, event-handler attributes, and `javascript:` URLs.
-- **`multipart/form-data` is no longer a stand-alone CSRF marker.** It is a
-  CORS-simple content type (sendable cross-origin with credentials and no
-  preflight), so the icon-upload endpoint was reachable by browser-form
-  CSRF. Uploads now require the `X-Requested-With` header, which the SPA
-  already sends.
-- **Docker lifecycle actions enforce per-app access.** A user who cleared
-  the lifecycle capability gate but was not allowed to see a given app
-  could still start/stop/restart its container; the per-app min-role and
-  group checks now apply to the control path too.
-- **`strip_frame_blockers` no longer strips a gateway site's framing
-  protection wholesale.** It now emits a `frame-ancestors 'self'
-  https://<dashboard>` policy scoped to the dashboard origin, so a framed
-  backend is embeddable by Muximux without being left open to clickjacking
-  from any origin.
-- **The dashboard's built-in users are honoured at gateway group gates.** A
-  built-in user's group memberships are now carried on the session, so a
-  gateway site with `allowed_groups` accepts them (previously only OIDC
-  users passed the gate).
-- `http_action` no longer follows HTTP redirects (SSRF): an action target
-  could redirect Muximux into probing link-local or loopback addresses.
-- Deleting a user now revokes their active sessions immediately, rather
-  than leaving the account usable until session expiry.
-- Restored bounded `ReadTimeout` / `ReadHeaderTimeout` on the HTTP server
-  (slowloris protection) alongside a rolling read deadline so large uploads
-  and streaming responses are not severed.
-
-### Changed
-- **The app add/edit modals are accessible dialogs.** They now expose
-  `role="dialog"` with an accessible name, trap keyboard focus while open,
-  and restore focus on close.
-- **The Docker action confirmation modal stays open while the action
-  runs.** It disables its controls, shows progress, and closes only when
-  the start/stop/restart resolves -- so a long restart gives feedback and
-  cannot be re-fired mid-flight.
-- Runtime Docker-discovery config changes are applied to the shared service
-  in place (with a stale-cache generation guard) instead of racing a
-  rebuild.
-- The health monitor is refreshed on every config save, so a newly added
-  app starts being health-checked without a restart.
+- **API keys are now hashed with SHA-256 instead of bcrypt.** Verifying an
+  API key ran bcrypt before authentication on every request bearing an
+  `X-Api-Key`, an unauthenticated CPU-amplification (DoS) vector. Keys are
+  high-entropy tokens, so a fast hash is equally brute-force-resistant.
+  Existing keys keep working and auto-upgrade on first use -- no rotation
+  needed.
+- **Uploaded icons are validated by their actual bytes, not the browser's
+  declared type**, closing a path where an upload claiming `image/svg+xml`
+  but carrying HTML/JS became stored XSS on the dashboard.
+- **The About-tab changelog is sanitized** (DOMPurify) before rendering the
+  remote update notes.
+- **Icon uploads require the `X-Requested-With` header** (`multipart/form-data`
+  alone is no longer accepted as a CSRF marker).
+- Deleting a user now revokes their active sessions immediately; enabling
+  built-in auth no longer briefly stores your password in the browser; and
+  `strip_frame_blockers` now scopes framing to the dashboard origin instead
+  of removing the protection entirely.
 
 ### Fixed
-- **Auto-import `sync` mode no longer wipes apps on a failed or empty
-  scan.** A transient daemon error, a self-detect failure, or a genuinely
-  empty scan could delete every auto-imported app and gateway site;
-  removals now require an app to be absent for several consecutive scans
-  (hysteresis) and are skipped entirely when a scan errors.
-- A Docker lifecycle state write (from a start/stop/restart) is no longer
-  clobbered by a poll tick that commits its full state map mid-action.
-- Oversized proxied responses are forwarded in full instead of being
-  truncated at the 50 MB rewrite limit.
-- `Content-Encoding` is classified by whole token, so a `gzip, br` chain is
-  no longer mis-handled as gzip.
-- Inline `<script>`/`<style>` blocks are excluded from root-path rewriting,
-  so proxied inline JS/CSS is left intact.
-- App create/update validate the app before persisting, so an invalid
-  `http_action` can no longer be written to disk and block the next boot.
-- Colliding app names are de-duplicated during auto-import, and a
-  daemon-down condition is warned once rather than every tick.
-- Fixed a data race between the discovery poller and `GET
-  /api/config/export`.
-- `config.Save` removes its temporary file when the final rename fails.
-- The final shutdown log line is written before the logger is closed
-  (previously it was dropped).
-- Enabling built-in auth from Settings no longer stores the plaintext
-  password in `sessionStorage`; it logs in before reloading instead.
+- **Auto-import `sync` no longer removes your apps when a Docker scan fails
+  or comes back empty.** A transient daemon error or a momentary empty scan
+  could previously delete every auto-imported app and gateway site.
+- **Proxied backends that send Brotli, Zstandard, or layered (`gzip, br`)
+  compressed responses now render correctly** instead of showing garbled
+  content, and legacy `x-gzip` backends keep working.
+- **Large proxied responses (over 50 MB) are delivered in full** instead of
+  being cut off.
+- **Modern single-page apps (Nuxt / Next / SvelteKit) that broke when
+  proxied now work** -- Muximux no longer rewrites paths inside a page's
+  inline scripts.
+- A newly added app starts being health-checked without a restart; colliding
+  auto-imported app names are de-duplicated; an invalid `http_action` is
+  rejected before it is saved (so it can't block startup); and a Docker
+  status indicator no longer briefly reverts after a start/stop/restart.
+
+Also includes internal hardening not visible in normal use: a config-export
+data race, resource-cleanup and shutdown-logging fixes, and discovery
+internals.
 
 ## [3.2.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ keys migrate themselves.
   remote update notes.
 - **Icon uploads require the `X-Requested-With` header** (`multipart/form-data`
   alone is no longer accepted as a CSRF marker).
+- **Container status is no longer exposed for apps a user cannot see.** The
+  docker-state endpoint (and its live updates) returned the status, image,
+  and uptime of every tracked app to any signed-in user; it now respects the
+  same `min_role` / `allowed_groups` visibility as the rest of the app.
 - Deleting a user now revokes their active sessions immediately; enabling
   built-in auth no longer briefly stores your password in the browser; and
   `strip_frame_blockers` now scopes framing to the dashboard origin instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ keys migrate themselves.
   action whose endpoint responded with a redirect, only the original URL is
   now requested (this closes a server-side request forgery vector). Direct
   webhook targets are unaffected.
-- **The app add/edit dialogs are now keyboard-accessible** -- focus is moved
-  into the dialog and trapped while it is open, restored on close, and
-  Escape closes it.
+- **The app add/edit and Docker-discovery dialogs are now keyboard-
+  accessible** -- focus is moved into the dialog and trapped while it is
+  open, restored on close, and Escape closes it.
 - **The Docker start/stop/restart confirmation shows progress** and stays
   open until the action finishes, instead of closing immediately.
 
@@ -57,6 +57,9 @@ keys migrate themselves.
   returned the status, image, uptime, and up/down state of every tracked app
   to any signed-in user; they now respect the same `min_role` /
   `allowed_groups` visibility as the rest of the app.
+- App, group, and icon colours are validated before being written into an
+  inline style, so a colour set via a Docker label can no longer inject
+  extra CSS declarations into the dashboard.
 - Deleting a user now revokes their active sessions immediately; enabling
   built-in auth no longer briefly stores your password in the browser; and
   `strip_frame_blockers` now scopes framing to the dashboard origin instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,11 @@ keys migrate themselves.
   remote update notes.
 - **Icon uploads require the `X-Requested-With` header** (`multipart/form-data`
   alone is no longer accepted as a CSRF marker).
-- **Container status is no longer exposed for apps a user cannot see.** The
-  docker-state endpoint (and its live updates) returned the status, image,
-  and uptime of every tracked app to any signed-in user; it now respects the
-  same `min_role` / `allowed_groups` visibility as the rest of the app.
+- **Container status and health are no longer exposed for apps a user cannot
+  see.** The docker-state and app-health endpoints (and their live updates)
+  returned the status, image, uptime, and up/down state of every tracked app
+  to any signed-in user; they now respect the same `min_role` /
+  `allowed_groups` visibility as the rest of the app.
 - Deleting a user now revokes their active sessions immediately; enabling
   built-in auth no longer briefly stores your password in the browser; and
   `strip_frame_blockers` now scopes framing to the dashboard origin instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,105 @@
 
 All notable changes to Muximux are documented in this file.
 
+## [3.3.0] - 2026-07-02
+
+A broad reliability, security, and accessibility pass across the whole
+stack -- the reverse proxy, Docker discovery, auth, config persistence, and
+the frontend. One new feature (identity forwarding to proxied backends);
+everything else hardens behaviour you already rely on. Drop-in: no config
+changes required.
+
+### Added
+- **Forward the signed-in user's identity to proxied backends.** Custom
+  proxy headers now expand `${user}`, `${role}`, `${email}`,
+  `${display_name}`, and `${groups}` to the current user's values, so a
+  backend behind Muximux can trust the dashboard's authentication instead
+  of running its own login. Values are stripped of CR/LF/NUL before being
+  sent. Documented in the reverse-proxy wiki page.
+
+### Security
+- **API keys are hashed with SHA-256 instead of bcrypt.** Verifying an
+  attacker-supplied `X-Api-Key` ran bcrypt before authentication on every
+  request -- an unauthenticated CPU-amplification (DoS) vector. API keys
+  are high-entropy tokens, so a fast constant-time hash is equally
+  brute-force-resistant. Existing bcrypt hashes keep working and are
+  auto-upgraded to the new form on first successful use (no manual key
+  rotation needed).
+- **Uploaded icons are type-checked by their bytes, not the client's
+  Content-Type.** A crafted upload could claim `image/svg+xml` while
+  carrying HTML/JS and be served back with that type -- stored XSS on the
+  dashboard origin. Uploads are now sniffed and an SVG claim is honoured
+  only when the bytes actually look like SVG.
+- **The remote changelog is sanitized before rendering.** The About tab
+  rendered update-check release notes through a markdown parser and
+  `{@html}`; the content is now run through DOMPurify first, stripping
+  scripts, event-handler attributes, and `javascript:` URLs.
+- **`multipart/form-data` is no longer a stand-alone CSRF marker.** It is a
+  CORS-simple content type (sendable cross-origin with credentials and no
+  preflight), so the icon-upload endpoint was reachable by browser-form
+  CSRF. Uploads now require the `X-Requested-With` header, which the SPA
+  already sends.
+- **Docker lifecycle actions enforce per-app access.** A user who cleared
+  the lifecycle capability gate but was not allowed to see a given app
+  could still start/stop/restart its container; the per-app min-role and
+  group checks now apply to the control path too.
+- **`strip_frame_blockers` no longer strips a gateway site's framing
+  protection wholesale.** It now emits a `frame-ancestors 'self'
+  https://<dashboard>` policy scoped to the dashboard origin, so a framed
+  backend is embeddable by Muximux without being left open to clickjacking
+  from any origin.
+- **The dashboard's built-in users are honoured at gateway group gates.** A
+  built-in user's group memberships are now carried on the session, so a
+  gateway site with `allowed_groups` accepts them (previously only OIDC
+  users passed the gate).
+- `http_action` no longer follows HTTP redirects (SSRF): an action target
+  could redirect Muximux into probing link-local or loopback addresses.
+- Deleting a user now revokes their active sessions immediately, rather
+  than leaving the account usable until session expiry.
+- Restored bounded `ReadTimeout` / `ReadHeaderTimeout` on the HTTP server
+  (slowloris protection) alongside a rolling read deadline so large uploads
+  and streaming responses are not severed.
+
+### Changed
+- **The app add/edit modals are accessible dialogs.** They now expose
+  `role="dialog"` with an accessible name, trap keyboard focus while open,
+  and restore focus on close.
+- **The Docker action confirmation modal stays open while the action
+  runs.** It disables its controls, shows progress, and closes only when
+  the start/stop/restart resolves -- so a long restart gives feedback and
+  cannot be re-fired mid-flight.
+- Runtime Docker-discovery config changes are applied to the shared service
+  in place (with a stale-cache generation guard) instead of racing a
+  rebuild.
+- The health monitor is refreshed on every config save, so a newly added
+  app starts being health-checked without a restart.
+
+### Fixed
+- **Auto-import `sync` mode no longer wipes apps on a failed or empty
+  scan.** A transient daemon error, a self-detect failure, or a genuinely
+  empty scan could delete every auto-imported app and gateway site;
+  removals now require an app to be absent for several consecutive scans
+  (hysteresis) and are skipped entirely when a scan errors.
+- A Docker lifecycle state write (from a start/stop/restart) is no longer
+  clobbered by a poll tick that commits its full state map mid-action.
+- Oversized proxied responses are forwarded in full instead of being
+  truncated at the 50 MB rewrite limit.
+- `Content-Encoding` is classified by whole token, so a `gzip, br` chain is
+  no longer mis-handled as gzip.
+- Inline `<script>`/`<style>` blocks are excluded from root-path rewriting,
+  so proxied inline JS/CSS is left intact.
+- App create/update validate the app before persisting, so an invalid
+  `http_action` can no longer be written to disk and block the next boot.
+- Colliding app names are de-duplicated during auto-import, and a
+  daemon-down condition is warned once rather than every tick.
+- Fixed a data race between the discovery poller and `GET
+  /api/config/export`.
+- `config.Save` removes its temporary file when the final rename fails.
+- The final shutdown log line is written before the logger is closed
+  (previously it was dropped).
+- Enabling built-in auth from Settings no longer stores the plaintext
+  password in `sessionStorage`; it logs in before reloading instead.
+
 ## [3.2.1] - 2026-07-01
 
 A follow-up to 3.2.0's automatic Docker import: auto-import now keeps

--- a/cmd/muximux/main.go
+++ b/cmd/muximux/main.go
@@ -202,6 +202,9 @@ func main() {
 		logging.Error("Error during shutdown", "source", "server", "error", err)
 	}
 
-	logging.Close()
+	// Emit the final line before tearing the logger down. Close() nils the
+	// writer and closes the underlying file, so any log call after it is
+	// written to a closed file and silently dropped.
 	logging.Info("Goodbye!", "source", "server")
+	logging.Close()
 }

--- a/docs/wiki/reverse-proxy.md
+++ b/docs/wiki/reverse-proxy.md
@@ -116,6 +116,28 @@ apps:
 | `proxy_skip_tls_verify` | `true` | When the backend uses HTTPS with a self-signed or internal CA certificate, this skips verification. Set to `false` if you want strict TLS validation. |
 | `proxy_headers` | (none) | Key-value map of headers added to every request forwarded to the backend. Useful for API keys or auth tokens the app requires. |
 
+#### Forwarding the signed-in user's identity
+
+A `proxy_headers` value can reference the authenticated Muximux user, so the backend can do header-based ("proxy") auth without its own login. Use any of these variables in a value:
+
+| Variable | Expands to |
+|---|---|
+| `${user}` | Username |
+| `${role}` | `admin` / `power-user` / `user` |
+| `${email}` | Email (if known) |
+| `${display_name}` | Display name |
+| `${groups}` | Group memberships, comma-separated |
+
+```yaml
+proxy_headers:
+  X-Forwarded-User: "${user}"
+  X-Forwarded-Groups: "${groups}"
+```
+
+The values are resolved per request from the current session and stripped of any CR/LF/NUL, so a crafted identity claim can't inject a header. On an unauthenticated instance (`auth.method: none`) the variables expand to empty. Static values (API keys, bearer tokens) are sent verbatim -- only values containing `${...}` are templated.
+
+> **Security:** these headers assert who the user is. The backend must accept them **only** from Muximux -- bind the backend to Muximux's network / an internal address so a client can't send `X-Forwarded-User` directly. This is the same trust model as any reverse-proxy header auth.
+
 The global `server.proxy_timeout` (default: `30s`) controls how long the proxy waits for a backend response before timing out. This applies to all proxied apps.
 
 ### When to Use It

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -84,6 +84,23 @@ type Middleware struct {
 	snap         atomic.Pointer[authSnapshot]
 	sessionStore *SessionStore
 	userStore    *UserStore
+
+	// onAPIKeyUpgrade, when set, is invoked after a successful API-key
+	// verify that used a legacy (bcrypt) stored hash, so the stored hash
+	// can be migrated to the fast sha256: form on first use -- closing the
+	// unauthenticated bcrypt DoS window without waiting for a manual key
+	// rotation. It is wired once at server setup (before serving) and read
+	// on the request path; apiKeyUpgrading gates it so a burst of
+	// concurrent legacy-key requests triggers at most one in-flight
+	// migration rather than one persist per request.
+	onAPIKeyUpgrade func(oldHash, newHash string)
+	apiKeyUpgrading atomic.Bool
+}
+
+// SetOnAPIKeyUpgrade wires the opportunistic legacy-hash migration hook.
+// Call once during setup, before the middleware serves any request.
+func (m *Middleware) SetOnAPIKeyUpgrade(fn func(oldHash, newHash string)) {
+	m.onAPIKeyUpgrade = fn
 }
 
 // NewMiddleware creates a new auth middleware
@@ -182,7 +199,7 @@ func (m *Middleware) RequireAuth(next http.Handler) http.Handler {
 
 		// Check bypass rules — still attempt best-effort auth so that
 		// bypassed endpoints (e.g. /api/auth/status) can see the user.
-		if shouldBypass(r, snap) {
+		if m.shouldBypass(r, snap) {
 			logging.From(r.Context()).Debug("Auth bypassed", "source", "auth", "path", r.URL.Path)
 			user, session := m.authenticateRequest(r, snap)
 			if user != nil {
@@ -302,19 +319,19 @@ func (m *Middleware) RequireRole(roles ...string) func(http.Handler) http.Handle
 	}
 }
 
-func shouldBypass(r *http.Request, snap *authSnapshot) bool {
+func (m *Middleware) shouldBypass(r *http.Request, snap *authSnapshot) bool {
 	for _, rule := range snap.config.BypassRules {
-		if matchBypassRule(r, rule, snap) {
+		if m.matchBypassRule(r, rule, snap) {
 			return true
 		}
 	}
 	return false
 }
 
-func matchBypassRule(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
+func (m *Middleware) matchBypassRule(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
 	return matchPath(r.URL.Path, rule) &&
 		matchMethod(r.Method, rule) &&
-		matchAPIKey(r, rule, snap) &&
+		m.matchAPIKey(r, rule, snap) &&
 		matchAllowedIPs(r, rule, snap)
 }
 
@@ -382,7 +399,7 @@ func VerifyAPIKey(provided, stored string) (ok bool, legacy bool) {
 	return bcrypt.CompareHashAndPassword([]byte(stored), []byte(provided)) == nil, true
 }
 
-func matchAPIKey(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
+func (m *Middleware) matchAPIKey(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
 	if !rule.RequireAPIKey {
 		return true
 	}
@@ -390,10 +407,25 @@ func matchAPIKey(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
 	if provided == "" || snap.config.APIKeyHash == "" {
 		return false
 	}
-	ok, _ := VerifyAPIKey(provided, snap.config.APIKeyHash)
+	ok, legacy := VerifyAPIKey(provided, snap.config.APIKeyHash)
 	if !ok {
 		logging.From(r.Context()).Warn("API key authentication failed", "source", "audit", "path", r.URL.Path)
 		return false
+	}
+	// Opportunistically migrate a legacy bcrypt hash to the fast sha256:
+	// form on first successful use. The verify above proved `provided` is
+	// the correct key, so sha256(provided) is a valid replacement. Pass
+	// the old hash too so the persist can compare-and-swap and skip if the
+	// stored hash changed (e.g. a concurrent rotation) since this verify.
+	// Fire at most one migration at a time; the disk write runs off the
+	// request goroutine so it never adds latency to the auth path.
+	if legacy && m.onAPIKeyUpgrade != nil && m.apiKeyUpgrading.CompareAndSwap(false, true) {
+		oldHash := snap.config.APIKeyHash
+		newHash := HashAPIKey(provided)
+		go func() {
+			defer m.apiKeyUpgrading.Store(false)
+			m.onAPIKeyUpgrade(oldHash, newHash)
+		}()
 	}
 	return true
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -2,6 +2,9 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"net"
 	"net/http"
 	"strings"
@@ -338,6 +341,41 @@ func matchMethod(method string, rule BypassRule) bool {
 	return false
 }
 
+// apiKeyHashPrefix marks the fast SHA-256 storage form of an API key.
+const apiKeyHashPrefix = "sha256:"
+
+// HashAPIKey returns the stored form of an API key. API keys are
+// high-entropy random tokens (not human passwords), so a plain SHA-256 is
+// as brute-force-resistant as bcrypt -- the key space is 2^256 -- without
+// bcrypt's per-verify CPU cost. That cost was an unauthenticated CPU-
+// amplification (DoS) vector on the API-key bypass path, since the compare
+// runs before authentication on every request bearing an X-Api-Key.
+func HashAPIKey(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return apiKeyHashPrefix + hex.EncodeToString(sum[:])
+}
+
+// VerifyAPIKey checks a presented key against the stored hash in constant
+// time. It accepts the new sha256: form (fast) and a legacy bcrypt hash
+// (backward compatible; slow, migrated on the next key rotation). The
+// bool return reports whether the match used the legacy bcrypt path, so
+// the caller can opportunistically upgrade the stored hash.
+func VerifyAPIKey(provided, stored string) (ok bool, legacy bool) {
+	if provided == "" || stored == "" {
+		return false, false
+	}
+	if rest, isSHA := strings.CutPrefix(stored, apiKeyHashPrefix); isSHA {
+		want, err := hex.DecodeString(rest)
+		if err != nil {
+			return false, false
+		}
+		got := sha256.Sum256([]byte(provided))
+		return subtle.ConstantTimeCompare(got[:], want) == 1, false
+	}
+	// Legacy bcrypt hash.
+	return bcrypt.CompareHashAndPassword([]byte(stored), []byte(provided)) == nil, true
+}
+
 func matchAPIKey(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
 	if !rule.RequireAPIKey {
 		return true
@@ -346,7 +384,8 @@ func matchAPIKey(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
 	if provided == "" || snap.config.APIKeyHash == "" {
 		return false
 	}
-	if bcrypt.CompareHashAndPassword([]byte(snap.config.APIKeyHash), []byte(provided)) != nil {
+	ok, _ := VerifyAPIKey(provided, snap.config.APIKeyHash)
+	if !ok {
 		logging.From(r.Context()).Warn("API key authentication failed", "source", "audit", "path", r.URL.Path)
 		return false
 	}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -357,9 +357,15 @@ func HashAPIKey(key string) string {
 
 // VerifyAPIKey checks a presented key against the stored hash in constant
 // time. It accepts the new sha256: form (fast) and a legacy bcrypt hash
-// (backward compatible; slow, migrated on the next key rotation). The
-// bool return reports whether the match used the legacy bcrypt path, so
-// the caller can opportunistically upgrade the stored hash.
+// (backward compatible; slow). A stored bcrypt hash is migrated to the
+// sha256: form when the key is next rotated (GenerateAPIKey); until then a
+// legacy install keeps paying bcrypt's per-verify cost, so the DoS
+// mitigation only takes full effect after a rotation.
+//
+// The legacy bool reports whether the match used the bcrypt path. It is
+// currently unused by matchAPIKey (which has no config-write path on the
+// auth hot path) but is returned so a future opportunistic-upgrade hook
+// can re-hash the presented key on a successful legacy verify.
 func VerifyAPIKey(provided, stored string) (ok bool, legacy bool) {
 	if provided == "" || stored == "" {
 		return false, false

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -379,15 +379,13 @@ func HashAPIKey(key string) string {
 
 // VerifyAPIKey checks a presented key against the stored hash in constant
 // time. It accepts the new sha256: form (fast) and a legacy bcrypt hash
-// (backward compatible; slow). A stored bcrypt hash is migrated to the
-// sha256: form when the key is next rotated (GenerateAPIKey); until then a
-// legacy install keeps paying bcrypt's per-verify cost, so the DoS
-// mitigation only takes full effect after a rotation.
+// (backward compatible; slow).
 //
-// The legacy bool reports whether the match used the bcrypt path. It is
-// currently unused by matchAPIKey (which has no config-write path on the
-// auth hot path) but is returned so a future opportunistic-upgrade hook
-// can re-hash the presented key on a successful legacy verify.
+// The legacy bool reports whether the match used the bcrypt path.
+// matchAPIKey consumes it to opportunistically migrate a legacy bcrypt hash
+// to the sha256: form on the first successful verify (via onAPIKeyUpgrade),
+// so an existing install closes the unauthenticated bcrypt DoS window
+// without waiting for a manual key rotation.
 func VerifyAPIKey(provided, stored string) (ok bool, legacy bool) {
 	if provided == "" || stored == "" {
 		return false, false

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -329,10 +329,15 @@ func (m *Middleware) shouldBypass(r *http.Request, snap *authSnapshot) bool {
 }
 
 func (m *Middleware) matchBypassRule(r *http.Request, rule BypassRule, snap *authSnapshot) bool {
+	// matchAPIKey is evaluated last because it carries a side effect (the
+	// opportunistic legacy-hash migration). Gating it behind the pure
+	// path/method/IP checks means the migration only fires for a request
+	// that actually clears the whole rule -- not for a correct key
+	// presented from a disallowed IP.
 	return matchPath(r.URL.Path, rule) &&
 		matchMethod(r.Method, rule) &&
-		m.matchAPIKey(r, rule, snap) &&
-		matchAllowedIPs(r, rule, snap)
+		matchAllowedIPs(r, rule, snap) &&
+		m.matchAPIKey(r, rule, snap)
 }
 
 func matchPath(requestPath string, rule BypassRule) bool {
@@ -424,6 +429,14 @@ func (m *Middleware) matchAPIKey(r *http.Request, rule BypassRule, snap *authSna
 		newHash := HashAPIKey(provided)
 		go func() {
 			defer m.apiKeyUpgrading.Store(false)
+			// net/http only recovers panics on its own serving
+			// goroutines; a panic here would crash the process. Contain
+			// it -- a failed migration must never take the server down.
+			defer func() {
+				if rec := recover(); rec != nil {
+					logging.Error("API key auto-upgrade hook panicked", "source", "audit", "panic", rec)
+				}
+			}()
 			m.onAPIKeyUpgrade(oldHash, newHash)
 		}()
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -383,7 +383,7 @@ func TestShouldBypass(t *testing.T) {
 				req.Header.Set(k, v)
 			}
 
-			got := shouldBypass(req, m.snapshot())
+			got := m.shouldBypass(req, m.snapshot())
 			if got != tt.want {
 				t.Errorf("shouldBypass() = %v, want %v", got, tt.want)
 			}
@@ -1091,13 +1091,69 @@ func TestMatchMethod(t *testing.T) {
 
 // --- matchAPIKey ---
 
+// TestMatchAPIKey_FiresLegacyUpgradeHook verifies the opportunistic
+// migration: a successful verify against a legacy bcrypt hash fires
+// onAPIKeyUpgrade with the old hash and the sha256 of the presented key.
+func TestMatchAPIKey_FiresLegacyUpgradeHook(t *testing.T) {
+	legacy := testHashAPIKey(t, "mysecret") // bcrypt
+	m, _, _ := newTestMiddleware(&AuthConfig{Method: AuthMethodBuiltin, APIKeyHash: legacy})
+
+	type upgrade struct{ oldHash, newHash string }
+	ch := make(chan upgrade, 1)
+	m.SetOnAPIKeyUpgrade(func(oldHash, newHash string) { ch <- upgrade{oldHash, newHash} })
+
+	snap := m.snapshot()
+	rule := BypassRule{RequireAPIKey: true}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Api-Key", "mysecret")
+	if !m.matchAPIKey(req, rule, snap) {
+		t.Fatal("expected the correct key to match")
+	}
+
+	select {
+	case u := <-ch:
+		if u.oldHash != legacy {
+			t.Errorf("old hash: got %q want %q", u.oldHash, legacy)
+		}
+		if want := HashAPIKey("mysecret"); u.newHash != want {
+			t.Errorf("new hash: got %q want %q", u.newHash, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("upgrade hook was not fired for a legacy bcrypt hash")
+	}
+}
+
+// TestMatchAPIKey_NoUpgradeForSHA256 verifies the hook does NOT fire when
+// the stored hash is already in the fast sha256: form.
+func TestMatchAPIKey_NoUpgradeForSHA256(t *testing.T) {
+	m, _, _ := newTestMiddleware(&AuthConfig{Method: AuthMethodBuiltin, APIKeyHash: HashAPIKey("mysecret")})
+
+	fired := make(chan struct{}, 1)
+	m.SetOnAPIKeyUpgrade(func(_, _ string) { fired <- struct{}{} })
+
+	snap := m.snapshot()
+	rule := BypassRule{RequireAPIKey: true}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Api-Key", "mysecret")
+	if !m.matchAPIKey(req, rule, snap) {
+		t.Fatal("expected the correct key to match")
+	}
+
+	select {
+	case <-fired:
+		t.Fatal("upgrade hook must not fire when the stored hash is already sha256")
+	case <-time.After(200 * time.Millisecond):
+		// no upgrade, as expected
+	}
+}
+
 func TestMatchAPIKey(t *testing.T) {
 	t.Run("not required always passes", func(t *testing.T) {
 		m, _, _ := newTestMiddleware(&AuthConfig{Method: AuthMethodBuiltin, APIKeyHash: testHashAPIKey(t, "secret")})
 		snap := m.snapshot()
 		rule := BypassRule{RequireAPIKey: false}
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		if !matchAPIKey(req, rule, snap) {
+		if !m.matchAPIKey(req, rule, snap) {
 			t.Error("expected true when not required")
 		}
 	})
@@ -1108,7 +1164,7 @@ func TestMatchAPIKey(t *testing.T) {
 		rule := BypassRule{RequireAPIKey: true}
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("X-Api-Key", "mysecret")
-		if !matchAPIKey(req, rule, snap) {
+		if !m.matchAPIKey(req, rule, snap) {
 			t.Error("expected true for correct API key")
 		}
 	})
@@ -1119,7 +1175,7 @@ func TestMatchAPIKey(t *testing.T) {
 		rule := BypassRule{RequireAPIKey: true}
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("X-Api-Key", "wrong")
-		if matchAPIKey(req, rule, snap) {
+		if m.matchAPIKey(req, rule, snap) {
 			t.Error("expected false for wrong API key")
 		}
 	})
@@ -1129,7 +1185,7 @@ func TestMatchAPIKey(t *testing.T) {
 		snap := m.snapshot()
 		rule := BypassRule{RequireAPIKey: true}
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		if matchAPIKey(req, rule, snap) {
+		if m.matchAPIKey(req, rule, snap) {
 			t.Error("expected false for missing API key")
 		}
 	})
@@ -1140,7 +1196,7 @@ func TestMatchAPIKey(t *testing.T) {
 		rule := BypassRule{RequireAPIKey: true}
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("X-Api-Key", "anything")
-		if matchAPIKey(req, rule, snap) {
+		if m.matchAPIKey(req, rule, snap) {
 			t.Error("expected false when no API key hash configured")
 		}
 	})

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1248,3 +1248,37 @@ func TestUpdateConfig_TrustedProxies(t *testing.T) {
 		t.Errorf("expected bob, got %s", user.Username)
 	}
 }
+
+// TestVerifyAPIKey covers the #16 fast-path: new sha256: hashes verify in
+// constant time, legacy bcrypt hashes still verify (and report legacy so
+// the caller can migrate), and mismatches/empties fail closed.
+func TestVerifyAPIKey(t *testing.T) {
+	key := "muximux_secret-token"
+	sha := HashAPIKey(key)
+	if len(sha) < 7 || sha[:7] != "sha256:" {
+		t.Fatalf("HashAPIKey format = %q", sha)
+	}
+	if ok, legacy := VerifyAPIKey(key, sha); !ok || legacy {
+		t.Errorf("sha256 verify: ok=%v legacy=%v; want true,false", ok, legacy)
+	}
+	if ok, _ := VerifyAPIKey("wrong-key", sha); ok {
+		t.Error("wrong key must not verify against a sha256 hash")
+	}
+
+	bc, err := bcrypt.GenerateFromPassword([]byte(key), bcrypt.MinCost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, legacy := VerifyAPIKey(key, string(bc)); !ok || !legacy {
+		t.Errorf("bcrypt verify: ok=%v legacy=%v; want true,true", ok, legacy)
+	}
+	if ok, _ := VerifyAPIKey("wrong-key", string(bc)); ok {
+		t.Error("wrong key must not verify against a bcrypt hash")
+	}
+	if ok, _ := VerifyAPIKey("", sha); ok {
+		t.Error("empty provided must not verify")
+	}
+	if ok, _ := VerifyAPIKey(key, ""); ok {
+		t.Error("empty stored must not verify")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1400,6 +1400,7 @@ func (c *Config) Save(path string) error {
 		return err
 	}
 	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName) // don't leave the temp file behind on a failed rename
 		return err
 	}
 	// fsync the parent directory so the rename hits stable storage

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1256,6 +1256,18 @@ func validateApps(apps []AppConfig) error {
 	return nil
 }
 
+// ValidateApp runs the per-app validation checks for a single app,
+// mirroring what validateApps enforces during boot-time Load. The API's
+// per-app create/update handlers call it so an invalid app is rejected
+// with a 400 up front rather than persisted (Config.Save does not
+// validate) and only surfaced as a config-load failure on the next boot.
+func ValidateApp(a *AppConfig) error {
+	if a.OpenMode != "http_action" {
+		return nil
+	}
+	return validateAppHTTPAction(a)
+}
+
 func validateAppHTTPAction(a *AppConfig) error {
 	if strings.TrimSpace(a.URL) == "" {
 		return fmt.Errorf("http_action requires a url")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1777,3 +1777,33 @@ func TestLoadDetachClearsAutoImported(t *testing.T) {
 			app.DockerKey, app.DockerAutoImported)
 	}
 }
+
+// TestSave_RemovesTempFileOnRenameFailure: every Save error path cleans
+// up its temp file except the final rename, which used to leak a
+// .config-*.yaml on failure. Force a rename failure by pointing Save at
+// an existing (non-empty) directory and assert no temp file is left.
+func TestSave_RemovesTempFileOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "config-as-dir")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "keep"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{Apps: []AppConfig{{Name: "a", URL: "http://a"}}}
+	if err := cfg.Save(target); err == nil {
+		t.Fatal("expected Save to fail renaming onto a directory")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".config-") {
+			t.Errorf("temp file leaked after failed rename: %s", e.Name())
+		}
+	}
+}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -698,11 +698,14 @@ func (s *Service) commitPolledDockerState(next dockerStateCache, sinceSeq uint64
 // SetDockerStateCache replaces the entire cache atomically. Retained for
 // tests and non-poll callers that intentionally want a wholesale reset;
 // the poller uses snapshotDockerStateForPoll + commitPolledDockerState so
-// it does not clobber concurrent lifecycle writes.
+// it does not clobber concurrent lifecycle writes. The manual-write
+// stamps are cleared too: a wholesale reset means "forget prior manual
+// tracking", so no orphaned stamp can over-preserve a later commit.
 func (s *Service) SetDockerStateCache(next dockerStateCache) {
 	s.dockerStateMu.Lock()
 	defer s.dockerStateMu.Unlock()
 	s.dockerState = next
+	s.dockerStateManualSeq = nil
 }
 
 // DockerStateSnapshot returns a defensive copy of the current cache

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -17,11 +17,11 @@ import (
 // results to keep the /status endpoint cheap, and tracks the
 // last-divergence state for the Settings banner.
 //
-// Service is constructed once per Server lifecycle. When discovery
-// config changes at runtime the Server replaces the Service rather
-// than mutating the existing one - the client transport may need
-// to be rebuilt (TLS settings, endpoint scheme), and rebuild-on-swap
-// is simpler than diff-and-reconfigure.
+// Service is constructed once per Server lifecycle and shared by the
+// poller, the lifecycle handlers, and the status handler. When discovery
+// config changes at runtime, Reconfigure rebuilds it IN PLACE (new client
+// transport, reset caches) under s.mu, so the single shared pointer
+// reflects the change everywhere without re-wiring each holder.
 type Service struct {
 	mu     sync.RWMutex
 	cfg    config.DiscoveryDockerConfig
@@ -65,10 +65,11 @@ type Service struct {
 	dockerStateMu sync.RWMutex
 	dockerState   dockerStateCache
 
-	// socketWritable is set once at Service construction by the
-	// capability probe. The lifecycle handlers return 503 when this
-	// is false; the Settings tab surfaces "socket is read-only" as a
-	// status line.
+	// socketWritable is set by the capability probe at construction and
+	// re-probed on every Reconfigure (reset to false first, so lifecycle
+	// fails closed until the new probe succeeds). The lifecycle handlers
+	// return 503 when this is false; the Settings tab surfaces "socket is
+	// read-only" as a status line.
 	socketWritable bool
 }
 
@@ -119,13 +120,37 @@ type StatusResult struct {
 // When the client cannot be built, the error is captured in
 // statusCache.LastError and surfaced via Status().
 func NewService(cfg *config.DiscoveryDockerConfig) *Service {
-	if cfg == nil {
-		return &Service{}
+	s := &Service{}
+	if cfg != nil {
+		s.Reconfigure(cfg)
 	}
-	s := &Service{cfg: *cfg}
+	return s
+}
+
+// Reconfigure rebuilds the service in place from a new discovery config.
+// The single *Service is shared by the poller, the lifecycle handlers,
+// and the status handler, so mutating in place -- rather than allocating
+// a fresh Service and swapping only one holder's pointer -- makes a
+// runtime config change (enable/disable discovery, or point at a
+// different daemon) take effect everywhere without a restart.
+//
+// Safe to call concurrently with readers: the cfg/client swap happens
+// under s.mu (readers take currentClient() / Scan() under the same
+// lock), and the socket probe runs after the lock is released so no I/O
+// is done while holding it.
+func (s *Service) Reconfigure(cfg *config.DiscoveryDockerConfig) {
+	s.mu.Lock()
+	s.cfg = *cfg
+	s.client = nil
+	// A different endpoint means a different (or no) "self" container and
+	// a stale status; force both to re-resolve.
+	s.selfChecked = false
+	s.selfInfo = nil
+	s.selfErr = nil
+	s.statusCache = StatusResult{}
+	s.statusCachedAt = time.Time{}
 	if cfg.Enabled && cfg.Endpoint != "" {
-		client, err := NewClient(cfg)
-		if err == nil {
+		if client, err := NewClient(cfg); err == nil {
 			s.client = client
 		} else {
 			s.statusCache = StatusResult{
@@ -137,18 +162,43 @@ func NewService(cfg *config.DiscoveryDockerConfig) *Service {
 			s.statusCachedAt = time.Now()
 		}
 	}
-	if s.client != nil {
-		// Best-effort probe with a short timeout so a slow socket
-		// doesn't block boot. The lifecycle flag stays false until
-		// the probe completes successfully. Running it synchronously
-		// here - before the Service is handed to any poller or
-		// handler - means socketWritable is stamped before any
-		// concurrent reader exists.
+	hasClient := s.client != nil
+	s.mu.Unlock()
+
+	// socketWritable lives under dockerStateMu; fail closed until the
+	// probe re-runs against the new client.
+	s.dockerStateMu.Lock()
+	s.socketWritable = false
+	s.dockerStateMu.Unlock()
+
+	if hasClient {
+		// Best-effort probe with a short timeout so a slow socket doesn't
+		// block the caller. The lifecycle flag stays false until it
+		// succeeds.
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		s.ProbeSocket(ctx)
 		cancel()
 	}
-	return s
+}
+
+// currentClient returns the active docker client under the read lock so a
+// concurrent Reconfigure can swap it without racing readers. nil when
+// discovery is disabled or the client failed to build.
+func (s *Service) currentClient() *Client {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.client
+}
+
+// snapshotCfg returns a copy of the current discovery config under the
+// read lock. Callers use the returned value for the duration of a call so
+// a concurrent Reconfigure can't tear a multi-field read. The struct is
+// copied by value; its slice fields are only ever replaced wholesale (by
+// Reconfigure), never mutated in place, so the shallow copy is safe.
+func (s *Service) snapshotCfg() config.DiscoveryDockerConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.cfg
 }
 
 // Status returns the cached capability state, refreshing the cache
@@ -160,7 +210,7 @@ func (s *Service) Status(ctx context.Context) StatusResult {
 	// reachability. socketWritable comes from the boot-time probe;
 	// lifecycle_enabled mirrors config.
 	r.SocketWritable = s.SocketWritable()
-	r.LifecycleEnabled = s.cfg.LifecycleEnabled
+	r.LifecycleEnabled = s.snapshotCfg().LifecycleEnabled
 	return r
 }
 
@@ -169,17 +219,18 @@ func (s *Service) Status(ctx context.Context) StatusResult {
 // the exported Status wrapper.
 func (s *Service) status(ctx context.Context) StatusResult {
 	s.mu.RLock()
+	cfg := s.cfg
 	cached := s.statusCache
 	cachedAt := s.statusCachedAt
 	clientPresent := s.client != nil
 	s.mu.RUnlock()
 
-	if !s.cfg.Enabled {
+	if !cfg.Enabled {
 		// Disabled - no client, no probe.
 		return StatusResult{
 			Configured: false,
-			Endpoint:   s.cfg.Endpoint,
-			Strategy:   s.cfg.NetworkStrategy,
+			Endpoint:   cfg.Endpoint,
+			Strategy:   cfg.NetworkStrategy,
 		}
 	}
 	if !clientPresent {
@@ -308,31 +359,44 @@ var errClientNotInitialised = errors.New("discovery client not initialised; chec
 // refreshStatus does the actual probe + selfDetect + TLS-hygiene
 // check, then caches the result.
 func (s *Service) refreshStatus(ctx context.Context) StatusResult {
+	s.mu.RLock()
+	cfg := s.cfg
+	client := s.client
+	s.mu.RUnlock()
+
 	r := StatusResult{
 		Configured: true,
-		Endpoint:   s.cfg.Endpoint,
-		Strategy:   s.cfg.NetworkStrategy,
+		Endpoint:   cfg.Endpoint,
+		Strategy:   cfg.NetworkStrategy,
 	}
 
 	// TLS file hygiene runs even when the daemon is unreachable so
 	// the operator gets the warning early.
-	if w := tlsHygieneWarning(&s.cfg.TLS); w != "" {
+	if w := tlsHygieneWarning(&cfg.TLS); w != "" {
 		r.TLSWarning = w
 	}
 
-	if err := s.client.Ping(ctx); err != nil {
+	// The client may have been cleared by a concurrent Reconfigure
+	// between status()'s presence check and here.
+	if client == nil {
+		r.LastError = errClientNotInitialised.Error()
+		s.cacheStatus(&r)
+		return r
+	}
+
+	if err := client.Ping(ctx); err != nil {
 		r.LastError = err.Error()
 		s.cacheStatus(&r)
 		return r
 	}
 	r.Reachable = true
 
-	if v, err := s.client.Version(ctx); err == nil {
+	if v, err := client.Version(ctx); err == nil {
 		r.APIVersion = v.APIVersion
 	}
 
 	// Strategy probe: only network-membership strategies need self-detect.
-	switch s.cfg.NetworkStrategy {
+	switch cfg.NetworkStrategy {
 	case config.StrategyContainerIP, config.StrategyContainerDNS:
 		s.mu.RLock()
 		checked := s.selfChecked
@@ -340,7 +404,7 @@ func (s *Service) refreshStatus(ctx context.Context) StatusResult {
 		selfErr := s.selfErr
 		s.mu.RUnlock()
 		if !checked {
-			info, selfErr = s.client.InspectSelf(ctx)
+			info, selfErr = client.InspectSelf(ctx)
 			s.mu.Lock()
 			s.selfChecked = true
 			s.selfInfo = info
@@ -351,7 +415,7 @@ func (s *Service) refreshStatus(ctx context.Context) StatusResult {
 		case selfErr == nil && info != nil:
 			r.StrategyOK = true
 			r.SelfDetect = string(info.Method)
-		case s.cfg.NetworkFilter != "":
+		case cfg.NetworkFilter != "":
 			// selfDetect failed but operator scoped via network_filter,
 			// which substitutes for self-membership.
 			r.StrategyOK = true
@@ -365,7 +429,7 @@ func (s *Service) refreshStatus(ctx context.Context) StatusResult {
 		r.StrategyOK = true
 	default:
 		r.StrategyOK = false
-		r.LastError = "unknown network_strategy: " + string(s.cfg.NetworkStrategy)
+		r.LastError = "unknown network_strategy: " + string(cfg.NetworkStrategy)
 	}
 
 	// Refresh-state telemetry (in-memory; resets on restart). Single
@@ -413,12 +477,11 @@ type ScanResult struct {
 // domains as "<container>.<dashboard-domain>" without us reaching
 // into the wider config from inside this package.
 func (s *Service) Scan(ctx context.Context, dashboardDomain string) ScanResult {
-	if !s.cfg.Enabled {
+	cfg := s.snapshotCfg()
+	if !cfg.Enabled {
 		return ScanResult{ScanBlocked: "Docker discovery is disabled. Enable it in Settings → Discovery."}
 	}
-	s.mu.RLock()
-	client := s.client
-	s.mu.RUnlock()
+	client := s.currentClient()
 	if client == nil {
 		return ScanResult{Error: "discovery client not initialised; check Settings → Discovery"}
 	}
@@ -427,9 +490,9 @@ func (s *Service) Scan(ctx context.Context, dashboardDomain string) ScanResult {
 	// successful self-detect OR an explicit network_filter. Without
 	// either, we'd be enumerating containers across every network
 	// visible to the daemon - a scope we don't control.
-	switch s.cfg.NetworkStrategy {
+	switch cfg.NetworkStrategy {
 	case "", config.StrategyContainerIP, config.StrategyContainerDNS:
-		if s.cfg.NetworkFilter == "" {
+		if cfg.NetworkFilter == "" {
 			s.mu.RLock()
 			info := s.selfInfo
 			selfErr := s.selfErr
@@ -455,7 +518,7 @@ func (s *Service) Scan(ctx context.Context, dashboardDomain string) ScanResult {
 
 	containers, err := client.ListContainers(ctx, ListContainersOpts{
 		All:     false,
-		Network: s.cfg.NetworkFilter,
+		Network: cfg.NetworkFilter,
 	})
 	if err != nil {
 		return ScanResult{Error: err.Error()}
@@ -473,8 +536,8 @@ func (s *Service) Scan(ctx context.Context, dashboardDomain string) ScanResult {
 		}
 		out.Suggestions = append(out.Suggestions, suggestForContainer(
 			&containers[i],
-			s.cfg.NetworkStrategy,
-			s.cfg.HostIP,
+			cfg.NetworkStrategy,
+			cfg.HostIP,
 			dashboardDomain,
 		))
 	}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -23,9 +23,22 @@ import (
 // transport, reset caches) under s.mu, so the single shared pointer
 // reflects the change everywhere without re-wiring each holder.
 type Service struct {
+	// reconfigureMu serializes Reconfigure calls end to end (including
+	// the post-swap socket probe) so two concurrent config updates can't
+	// interleave and leave socketWritable reflecting a client that is no
+	// longer current. Distinct from mu: readers take mu (fast), never
+	// this, so a slow probe under reconfigureMu doesn't block them.
+	reconfigureMu sync.Mutex
+
 	mu     sync.RWMutex
 	cfg    config.DiscoveryDockerConfig
 	client *Client // nil when discovery is disabled or NewClient failed
+	// cfgGen increments on every Reconfigure. Long-running probes
+	// (refreshStatus/Scan self-detect) capture it before their I/O and
+	// discard their cache write-back if it changed underneath them, so a
+	// probe against a now-replaced daemon can't stamp stale self-detect
+	// onto the live Service.
+	cfgGen uint64
 
 	// Capability cache. statusCacheTTL is short (30s) because the
 	// /status endpoint is hit on every Settings page load and the
@@ -139,7 +152,14 @@ func NewService(cfg *config.DiscoveryDockerConfig) *Service {
 // lock), and the socket probe runs after the lock is released so no I/O
 // is done while holding it.
 func (s *Service) Reconfigure(cfg *config.DiscoveryDockerConfig) {
+	// Serialize whole reconfigures so the final socketWritable probe
+	// belongs to the final client (fixes a fail-open window under
+	// concurrent admin config edits).
+	s.reconfigureMu.Lock()
+	defer s.reconfigureMu.Unlock()
+
 	s.mu.Lock()
+	s.cfgGen++
 	s.cfg = *cfg
 	s.client = nil
 	// A different endpoint means a different (or no) "self" container and
@@ -360,6 +380,7 @@ var errClientNotInitialised = errors.New("discovery client not initialised; chec
 // check, then caches the result.
 func (s *Service) refreshStatus(ctx context.Context) StatusResult {
 	s.mu.RLock()
+	gen := s.cfgGen
 	cfg := s.cfg
 	client := s.client
 	s.mu.RUnlock()
@@ -406,9 +427,11 @@ func (s *Service) refreshStatus(ctx context.Context) StatusResult {
 		if !checked {
 			info, selfErr = client.InspectSelf(ctx)
 			s.mu.Lock()
-			s.selfChecked = true
-			s.selfInfo = info
-			s.selfErr = selfErr
+			if s.cfgGen == gen { // config unchanged under us; safe to cache
+				s.selfChecked = true
+				s.selfInfo = info
+				s.selfErr = selfErr
+			}
 			s.mu.Unlock()
 		}
 		switch {
@@ -494,6 +517,7 @@ func (s *Service) Scan(ctx context.Context, dashboardDomain string) ScanResult {
 	case "", config.StrategyContainerIP, config.StrategyContainerDNS:
 		if cfg.NetworkFilter == "" {
 			s.mu.RLock()
+			gen := s.cfgGen
 			info := s.selfInfo
 			selfErr := s.selfErr
 			checked := s.selfChecked
@@ -501,9 +525,11 @@ func (s *Service) Scan(ctx context.Context, dashboardDomain string) ScanResult {
 			if !checked {
 				info, selfErr = client.InspectSelf(ctx)
 				s.mu.Lock()
-				s.selfChecked = true
-				s.selfInfo = info
-				s.selfErr = selfErr
+				if s.cfgGen == gen { // config unchanged under us; safe to cache
+					s.selfChecked = true
+					s.selfInfo = info
+					s.selfErr = selfErr
+				}
 				s.mu.Unlock()
 			}
 			if selfErr != nil || info == nil {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -78,6 +78,16 @@ type Service struct {
 	dockerStateMu sync.RWMutex
 	dockerState   dockerStateCache
 
+	// dockerStateSeq is a monotonic counter bumped on every manual
+	// (lifecycle-handler) write to dockerState, and manualSeq records the
+	// counter value at each app's last manual write. The poller captures
+	// the counter when it snapshots the cache and hands it back at commit
+	// time so its wholesale map replacement does not clobber a lifecycle
+	// write that landed mid-tick (the write exists precisely to show fresh
+	// post-action state before the next poll). Guarded by dockerStateMu.
+	dockerStateSeq       uint64
+	dockerStateManualSeq map[string]uint64
+
 	// socketWritable is set by the capability probe at construction and
 	// re-probed on every Reconfigure (reset to false first, so lifecycle
 	// fails closed until the new probe succeeds). The lifecycle handlers
@@ -627,12 +637,68 @@ func (s *Service) SetDockerStateForApp(name string, st *DockerState) {
 	if s.dockerState == nil {
 		s.dockerState = make(dockerStateCache)
 	}
+	if s.dockerStateManualSeq == nil {
+		s.dockerStateManualSeq = make(map[string]uint64)
+	}
+	s.dockerStateSeq++
 	s.dockerState[name] = *st
+	s.dockerStateManualSeq[name] = s.dockerStateSeq
 }
 
-// SetDockerStateCache replaces the entire cache atomically. The poller
-// calls this at the end of each tick with the freshly-built map so
-// apps that disappeared from the tracked set are pruned in one step.
+// snapshotDockerStateForPoll returns a defensive copy of the current cache
+// together with the manual-write sequence counter at snapshot time. The
+// poller pairs it with commitPolledDockerState so a lifecycle write that
+// lands while the tick is inspecting containers is not lost.
+func (s *Service) snapshotDockerStateForPoll() (dockerStateCache, uint64) {
+	s.dockerStateMu.RLock()
+	defer s.dockerStateMu.RUnlock()
+	out := make(dockerStateCache, len(s.dockerState))
+	for k, v := range s.dockerState {
+		out[k] = v
+	}
+	return out, s.dockerStateSeq
+}
+
+// commitPolledDockerState replaces the cache with the poller's freshly
+// built map, but preserves any entry a lifecycle handler wrote after the
+// poll snapshot was taken (manualSeq > sinceSeq). Without this guard the
+// wholesale replacement would clobber a Start/Stop/Restart result that
+// landed mid-tick, blinking the status pill back to its pre-action state
+// until the next poll. Vanished apps (absent from next and not freshly
+// written) are still pruned. sinceSeq is the counter returned by
+// snapshotDockerStateForPoll at the start of the tick.
+func (s *Service) commitPolledDockerState(next dockerStateCache, sinceSeq uint64) {
+	s.dockerStateMu.Lock()
+	defer s.dockerStateMu.Unlock()
+	// Preserve fresher lifecycle writes: for any app still tracked (present
+	// in next) whose last manual write happened after the snapshot, keep
+	// the current entry instead of the poll's possibly-staler read.
+	for name, seq := range s.dockerStateManualSeq {
+		if seq <= sinceSeq {
+			continue
+		}
+		if _, tracked := next[name]; tracked {
+			if cur, ok := s.dockerState[name]; ok {
+				next[name] = cur
+			}
+		}
+	}
+	// Carry forward manual-seq stamps only for apps that survive in the new
+	// cache, so the map does not grow without bound as apps come and go.
+	prunedSeq := make(map[string]uint64, len(s.dockerStateManualSeq))
+	for name, seq := range s.dockerStateManualSeq {
+		if _, ok := next[name]; ok {
+			prunedSeq[name] = seq
+		}
+	}
+	s.dockerState = next
+	s.dockerStateManualSeq = prunedSeq
+}
+
+// SetDockerStateCache replaces the entire cache atomically. Retained for
+// tests and non-poll callers that intentionally want a wholesale reset;
+// the poller uses snapshotDockerStateForPoll + commitPolledDockerState so
+// it does not clobber concurrent lifecycle writes.
 func (s *Service) SetDockerStateCache(next dockerStateCache) {
 	s.dockerStateMu.Lock()
 	defer s.dockerStateMu.Unlock()

--- a/internal/discovery/docker_state_test.go
+++ b/internal/discovery/docker_state_test.go
@@ -39,6 +39,61 @@ func TestDockerStateCache_ReplaceAll(t *testing.T) {
 	}
 }
 
+// TestCommitPolledDockerState_PreservesMidTickLifecycleWrite reproduces the
+// lost-update the seq guard closes: a poll tick snapshots the cache, then a
+// lifecycle handler writes a fresh post-action state while the tick is still
+// inspecting, then the tick commits its wholesale map. The lifecycle write
+// must survive -- it exists precisely to show fresh state before the next
+// poll. A plain wholesale replace (the old SetDockerStateCache) would revert
+// "web" to the poll's staler "exited" read.
+func TestCommitPolledDockerState_PreservesMidTickLifecycleWrite(t *testing.T) {
+	s := &Service{}
+	// Poll snapshot sees the container stopped.
+	s.SetDockerStateForApp("web", &DockerState{Status: "exited"})
+	prev, sinceSeq := s.snapshotDockerStateForPoll()
+	if _, ok := prev["web"]; !ok {
+		t.Fatalf("snapshot should contain web")
+	}
+
+	// Lifecycle Start lands mid-tick, after the snapshot.
+	s.SetDockerStateForApp("web", &DockerState{Status: "running"})
+
+	// The tick built next from its (pre-action) inspect: still "exited".
+	next := dockerStateCache{"web": {Status: "exited"}}
+	s.commitPolledDockerState(next, sinceSeq)
+
+	if got, _ := s.DockerStateForApp("web"); got.Status != "running" {
+		t.Fatalf("mid-tick lifecycle write was clobbered: want running, got %q", got.Status)
+	}
+}
+
+// TestCommitPolledDockerState_PollWinsAndPrunes verifies the guard does not
+// over-preserve: a manual write from BEFORE the snapshot must not override a
+// fresher poll read, and apps absent from next are still pruned.
+func TestCommitPolledDockerState_PollWinsAndPrunes(t *testing.T) {
+	s := &Service{}
+	s.SetDockerStateForApp("web", &DockerState{Status: "running"})
+	s.SetDockerStateForApp("gone", &DockerState{Status: "exited"})
+	prev, sinceSeq := s.snapshotDockerStateForPoll()
+	_ = prev
+
+	// No lifecycle write after the snapshot. Poll sees web stopped and no
+	// longer tracks "gone".
+	next := dockerStateCache{"web": {Status: "exited"}}
+	s.commitPolledDockerState(next, sinceSeq)
+
+	if got, _ := s.DockerStateForApp("web"); got.Status != "exited" {
+		t.Fatalf("poll read should win when no newer manual write: want exited, got %q", got.Status)
+	}
+	if _, ok := s.DockerStateForApp("gone"); ok {
+		t.Fatalf("vanished app should be pruned")
+	}
+	// The manual-seq stamp for the pruned app must not linger.
+	if _, ok := s.dockerStateManualSeq["gone"]; ok {
+		t.Fatalf("manual-seq stamp for pruned app should be dropped")
+	}
+}
+
 func TestDockerStateCache_Snapshot_ReturnsCopy(t *testing.T) {
 	s := &Service{}
 	s.SetDockerStateForApp("a", &DockerState{Status: "running"})

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -307,24 +307,35 @@ func (p *Poller) tick(ctx context.Context) {
 	// this is not a double-write bug.
 	if autoImport != config.AutoImportOff {
 		scan := svc.Scan(ctx, dashboardDomain)
-		desired := make([]Desired, 0, len(scan.Suggestions))
-		for i := range scan.Suggestions {
-			desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
-		}
-		plan := Reconcile(autoImport, desired, currentApps, currentSites)
-		for i := range plan.Add {
-			batch.addApps = append(batch.addApps, plan.Add[i].App)
-			if plan.Add[i].Site != nil {
-				batch.addSites = append(batch.addSites, *plan.Add[i].Site)
+		// A failed or blocked scan yields no suggestions. Treating that
+		// empty result as the desired set would make sync mode conclude
+		// every labeled container vanished and delete every auto-imported
+		// app + gateway site (data loss on a transient daemon hiccup or a
+		// self-detect failure). Skip reconcile until the scan succeeds
+		// again; the URL-refresh batch built above still commits below.
+		if scan.Error != "" || scan.ScanBlocked != "" {
+			logging.Warn("Discovery auto-import skipped: scan did not complete",
+				"source", "discovery", "error", scan.Error, "blocked", scan.ScanBlocked)
+		} else {
+			desired := make([]Desired, 0, len(scan.Suggestions))
+			for i := range scan.Suggestions {
+				desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
 			}
-		}
-		for i := range plan.Update {
-			batch.updateApps = append(batch.updateApps, plan.Update[i].App)
-			if plan.Update[i].Site != nil {
-				batch.updateSites = append(batch.updateSites, *plan.Update[i].Site)
+			plan := Reconcile(autoImport, desired, currentApps, currentSites)
+			for i := range plan.Add {
+				batch.addApps = append(batch.addApps, plan.Add[i].App)
+				if plan.Add[i].Site != nil {
+					batch.addSites = append(batch.addSites, *plan.Add[i].Site)
+				}
 			}
+			for i := range plan.Update {
+				batch.updateApps = append(batch.updateApps, plan.Update[i].App)
+				if plan.Update[i].Site != nil {
+					batch.updateSites = append(batch.updateSites, *plan.Update[i].Site)
+				}
+			}
+			batch.removeKeys = append(batch.removeKeys, plan.RemoveKeys...)
 		}
-		batch.removeKeys = append(batch.removeKeys, plan.RemoveKeys...)
 	}
 
 	if batch.empty() {

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -77,20 +77,24 @@ type Poller struct {
 // 60s refresh interval this is roughly a 2-minute grace.
 const syncRemovalGraceTicks = 3
 
-// gateSyncRemovals applies removal hysteresis to the sync-mode removal
-// candidates. It advances a per-key absence counter and returns only the
-// keys that have now been absent for syncRemovalGraceTicks consecutive
-// scans. Candidates that reappear (or that this tick no longer proposes)
-// drop out of the counter, so a container that returns within the grace
-// window is never removed and re-added.
 // dedupeDesiredNames drops desired entries whose app Name collides with
-// an earlier one, so two containers that resolve to the same name (a
-// duplicated muximux.app.name label, or two containers of the same
-// catalog app) don't create duplicate app entries in the config. The
-// winner is chosen deterministically (lowest DockerKey) so the same
-// container consistently keeps the name across ticks rather than the two
-// flapping. The operator is warned to give them distinct names.
-func dedupeDesiredNames(desired []Desired) []Desired {
+// another desired entry OR with a currently-configured app under a
+// different DockerKey, so auto-import never writes a duplicate app name.
+// Deduping only within the desired set was insufficient: a
+// hysteresis-deferred removal keeps the old app for a few ticks, so a new
+// lower-key container of the same name would be added immediately and
+// briefly coexist with the incumbent. Within the desired set the winner
+// is the lowest DockerKey (deterministic across ticks); against the
+// existing config the incumbent always keeps its name. The operator is
+// warned to give colliding containers distinct names.
+func dedupeDesiredNames(desired []Desired, currentApps []config.AppConfig) []Desired {
+	// Names already held in the config -> the owning DockerKey ("" for a
+	// manual/hand-detached app). A desired entry under a different key
+	// must not reuse the name.
+	taken := make(map[string]string, len(currentApps))
+	for i := range currentApps {
+		taken[currentApps[i].Name] = currentApps[i].DockerKey
+	}
 	sort.SliceStable(desired, func(i, j int) bool {
 		return desired[i].App.DockerKey < desired[j].App.DockerKey
 	})
@@ -98,18 +102,29 @@ func dedupeDesiredNames(desired []Desired) []Desired {
 	out := desired[:0]
 	for i := range desired {
 		name := desired[i].App.Name
-		if winner, dup := seen[name]; dup {
-			logging.Warn("Discovery auto-import: duplicate app name; skipping the second container",
-				"source", "discovery", "name", name,
-				"kept_key", winner, "skipped_key", desired[i].App.DockerKey)
+		key := desired[i].App.DockerKey
+		if owner, held := taken[name]; held && owner != key {
+			logging.Warn("Discovery auto-import: app name already in use; skipping container",
+				"source", "discovery", "name", name, "owner_key", owner, "skipped_key", key)
 			continue
 		}
-		seen[name] = desired[i].App.DockerKey
+		if winner, dup := seen[name]; dup {
+			logging.Warn("Discovery auto-import: duplicate app name; skipping the second container",
+				"source", "discovery", "name", name, "kept_key", winner, "skipped_key", key)
+			continue
+		}
+		seen[name] = key
 		out = append(out, desired[i])
 	}
 	return out
 }
 
+// gateSyncRemovals applies removal hysteresis to the sync-mode removal
+// candidates. It advances a per-key absence counter and returns only the
+// keys that have now been absent for syncRemovalGraceTicks consecutive
+// scans. Candidates that reappear (or that this tick no longer proposes)
+// drop out of the counter, so a container that returns within the grace
+// window is never removed and re-added.
 func (p *Poller) gateSyncRemovals(candidates []string) []string {
 	if len(candidates) == 0 {
 		p.syncAbsent = nil
@@ -412,7 +427,7 @@ func (p *Poller) tick(ctx context.Context) {
 			for i := range scan.Suggestions {
 				desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
 			}
-			desired = dedupeDesiredNames(desired)
+			desired = dedupeDesiredNames(desired, currentApps)
 			plan := Reconcile(autoImport, desired, currentApps, currentSites)
 			for i := range plan.Add {
 				batch.addApps = append(batch.addApps, plan.Add[i].App)

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -964,6 +964,16 @@ func (p *Poller) refreshDockerState(ctx context.Context, tracked trackedSet) {
 		return
 	}
 
+	// Capture the manual-write watermark BEFORE any daemon read. next is
+	// built from container data read at/after ListContainers below, so a
+	// lifecycle write that lands concurrently with those reads must count
+	// as "after the snapshot" (seq > sinceSeq) to be preserved at commit.
+	// Snapshotting after ListContainers would leave a window where such a
+	// write is stamped seq <= sinceSeq yet next is staler than it -- e.g.
+	// a Start that creates a container the list predates, which resolves
+	// to "missing" and would otherwise clobber the fresh "running".
+	prev, sinceSeq := svc.snapshotDockerStateForPoll()
+
 	// State resolution lists ALL containers, including stopped ones.
 	// The URL-refresh scan above is running-only (a stopped container
 	// has no IP to resolve), but a stopped *tracked* container must
@@ -996,7 +1006,6 @@ func (p *Poller) refreshDockerState(ctx context.Context, tracked trackedSet) {
 		}
 	}
 
-	prev, sinceSeq := svc.snapshotDockerStateForPoll()
 	inspect := func(ctx context.Context, id string) (DockerState, error) {
 		return client.InspectContainerState(ctx, id)
 	}

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -996,12 +996,14 @@ func (p *Poller) refreshDockerState(ctx context.Context, tracked trackedSet) {
 		}
 	}
 
-	prev := svc.DockerStateSnapshot()
+	prev, sinceSeq := svc.snapshotDockerStateForPoll()
 	inspect := func(ctx context.Context, id string) (DockerState, error) {
 		return client.InspectContainerState(ctx, id)
 	}
 	next := buildDockerStateCache(ctx, tracked.apps, resolved, inspect, prev)
-	svc.SetDockerStateCache(next)
+	// Commit without clobbering any lifecycle write that landed while we
+	// were inspecting (sinceSeq is the manual-write counter at snapshot).
+	svc.commitPolledDockerState(next, sinceSeq)
 
 	diffs := diffDockerStates(prev, next)
 	if p.deps.BroadcastDockerStateChanged != nil {

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -82,6 +83,33 @@ const syncRemovalGraceTicks = 3
 // scans. Candidates that reappear (or that this tick no longer proposes)
 // drop out of the counter, so a container that returns within the grace
 // window is never removed and re-added.
+// dedupeDesiredNames drops desired entries whose app Name collides with
+// an earlier one, so two containers that resolve to the same name (a
+// duplicated muximux.app.name label, or two containers of the same
+// catalog app) don't create duplicate app entries in the config. The
+// winner is chosen deterministically (lowest DockerKey) so the same
+// container consistently keeps the name across ticks rather than the two
+// flapping. The operator is warned to give them distinct names.
+func dedupeDesiredNames(desired []Desired) []Desired {
+	sort.SliceStable(desired, func(i, j int) bool {
+		return desired[i].App.DockerKey < desired[j].App.DockerKey
+	})
+	seen := make(map[string]string, len(desired)) // name -> winning DockerKey
+	out := desired[:0]
+	for i := range desired {
+		name := desired[i].App.Name
+		if winner, dup := seen[name]; dup {
+			logging.Warn("Discovery auto-import: duplicate app name; skipping the second container",
+				"source", "discovery", "name", name,
+				"kept_key", winner, "skipped_key", desired[i].App.DockerKey)
+			continue
+		}
+		seen[name] = desired[i].App.DockerKey
+		out = append(out, desired[i])
+	}
+	return out
+}
+
 func (p *Poller) gateSyncRemovals(candidates []string) []string {
 	if len(candidates) == 0 {
 		p.syncAbsent = nil
@@ -377,6 +405,7 @@ func (p *Poller) tick(ctx context.Context) {
 			for i := range scan.Suggestions {
 				desired = append(desired, BuildDesired(&scan.Suggestions[i], endpoint))
 			}
+			desired = dedupeDesiredNames(desired)
 			plan := Reconcile(autoImport, desired, currentApps, currentSites)
 			for i := range plan.Add {
 				batch.addApps = append(batch.addApps, plan.Add[i].App)

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -55,6 +55,45 @@ type Poller struct {
 	// warning - we want to surface a config typo once when it
 	// happens (or on the first tick after edit), not every tick.
 	lastBadInterval string
+	// syncAbsent tracks how many consecutive successful scans each
+	// sync-mode removal candidate has been missing (removal
+	// hysteresis). See gateSyncRemovals. Only touched from tick(),
+	// which runs one at a time, so it needs no lock.
+	syncAbsent map[string]int
+}
+
+// syncRemovalGraceTicks is how many consecutive successful scans a
+// tracked container must be absent before sync mode removes its app and
+// gateway site. This stops a single transient empty or partial scan (a
+// mass container restart, or a network_filter that briefly matches
+// nothing) from wiping every auto-imported entry, while still honoring
+// the GitOps-mirror contract once the absence persists. At the default
+// 60s refresh interval this is roughly a 2-minute grace.
+const syncRemovalGraceTicks = 3
+
+// gateSyncRemovals applies removal hysteresis to the sync-mode removal
+// candidates. It advances a per-key absence counter and returns only the
+// keys that have now been absent for syncRemovalGraceTicks consecutive
+// scans. Candidates that reappear (or that this tick no longer proposes)
+// drop out of the counter, so a container that returns within the grace
+// window is never removed and re-added.
+func (p *Poller) gateSyncRemovals(candidates []string) []string {
+	if len(candidates) == 0 {
+		p.syncAbsent = nil
+		return nil
+	}
+	next := make(map[string]int, len(candidates))
+	var ready []string
+	for _, k := range candidates {
+		n := p.syncAbsent[k] + 1
+		if n >= syncRemovalGraceTicks {
+			ready = append(ready, k)
+			continue
+		}
+		next[k] = n
+	}
+	p.syncAbsent = next
+	return ready
 }
 
 // NewPoller returns a configured Poller. It does NOT start the
@@ -334,7 +373,7 @@ func (p *Poller) tick(ctx context.Context) {
 					batch.updateSites = append(batch.updateSites, *plan.Update[i].Site)
 				}
 			}
-			batch.removeKeys = append(batch.removeKeys, plan.RemoveKeys...)
+			batch.removeKeys = append(batch.removeKeys, p.gateSyncRemovals(plan.RemoveKeys)...)
 		}
 	}
 

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -282,7 +282,14 @@ func (p *Poller) tick(ctx context.Context) {
 	}
 
 	svc := p.deps.Service
-	if svc == nil || svc.client == nil {
+	if svc == nil {
+		return
+	}
+	// Snapshot the client once for the whole tick under the Service lock,
+	// so a runtime Reconfigure (endpoint change) swaps it cleanly between
+	// ticks rather than mid-tick.
+	client := svc.currentClient()
+	if client == nil {
 		return
 	}
 
@@ -294,7 +301,7 @@ func (p *Poller) tick(ctx context.Context) {
 	// for the full tick. A daemon listing failure aborts the tick
 	// cleanly - we don't want to half-resolve and possibly mark
 	// containers as "not found" because the daemon was unreachable.
-	containers, err := svc.client.ListContainers(ctx, ListContainersOpts{All: false})
+	containers, err := client.ListContainers(ctx, ListContainersOpts{All: false})
 	if err != nil {
 		if !p.daemonDown {
 			p.daemonDown = true
@@ -934,7 +941,11 @@ func diffDockerStates(prev, next map[string]DockerState) []dockerStateDiff {
 // changes. Runs at the end of every tick after the URL refresh batch.
 func (p *Poller) refreshDockerState(ctx context.Context, tracked trackedSet) {
 	svc := p.deps.Service
-	if svc == nil || svc.client == nil {
+	if svc == nil {
+		return
+	}
+	client := svc.currentClient()
+	if client == nil {
 		return
 	}
 
@@ -944,7 +955,7 @@ func (p *Poller) refreshDockerState(ctx context.Context, tracked trackedSet) {
 	// still read as its real state ("exited") so the dashboard keeps
 	// offering Start. Resolving it against the running-only list would
 	// drop it to "missing" and the lifecycle actions would vanish.
-	containers, err := svc.client.ListContainers(ctx, ListContainersOpts{All: true})
+	containers, err := client.ListContainers(ctx, ListContainersOpts{All: true})
 	if err != nil {
 		// Transient daemon failure: leave the cache untouched rather
 		// than blinking every tracked app to "missing" for one tick.
@@ -972,7 +983,7 @@ func (p *Poller) refreshDockerState(ctx context.Context, tracked trackedSet) {
 
 	prev := svc.DockerStateSnapshot()
 	inspect := func(ctx context.Context, id string) (DockerState, error) {
-		return svc.client.InspectContainerState(ctx, id)
+		return client.InspectContainerState(ctx, id)
 	}
 	next := buildDockerStateCache(ctx, tracked.apps, resolved, inspect, prev)
 	svc.SetDockerStateCache(next)

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -60,6 +60,11 @@ type Poller struct {
 	// hysteresis). See gateSyncRemovals. Only touched from tick(),
 	// which runs one at a time, so it needs no lock.
 	syncAbsent map[string]int
+	// daemonDown dedupes the "daemon unreachable" warning: we log once
+	// when the container listing starts failing and once when it
+	// recovers, instead of every tick for the duration of an outage.
+	// Only touched from tick().
+	daemonDown bool
 }
 
 // syncRemovalGraceTicks is how many consecutive successful scans a
@@ -263,9 +268,16 @@ func (p *Poller) tick(ctx context.Context) {
 	// containers as "not found" because the daemon was unreachable.
 	containers, err := svc.client.ListContainers(ctx, ListContainersOpts{All: false})
 	if err != nil {
-		logging.Warn("Discovery refresh skipped: ListContainers failed",
-			"source", "discovery", "error", err.Error())
+		if !p.daemonDown {
+			p.daemonDown = true
+			logging.Warn("Discovery refresh skipped: ListContainers failed (retrying each tick; suppressing repeats until recovery)",
+				"source", "discovery", "error", err.Error())
+		}
 		return
+	}
+	if p.daemonDown {
+		p.daemonDown = false
+		logging.Info("Discovery daemon reachable again", "source", "discovery")
 	}
 
 	// Resolve each tracked entry's container -> new URL. Skips
@@ -918,6 +930,10 @@ func (p *Poller) refreshDockerState(ctx context.Context, tracked trackedSet) {
 		t := &tracked.apps[i]
 		tk, err := ParseTrackingKey(t.key)
 		if err != nil {
+			// Consistent with the URL-refresh pass: surface a malformed
+			// tracking key instead of silently skipping it.
+			logging.Warn("Docker state refresh: unparseable tracking key",
+				"source", "discovery", "name", t.name, "key", t.key, "error", err.Error())
 			continue
 		}
 		if m := tk.FindContainer(containers); m != nil {

--- a/internal/discovery/poller.go
+++ b/internal/discovery/poller.go
@@ -110,8 +110,12 @@ func NewPoller(deps PollerDeps) *Poller {
 // any URL drift right away. Subsequent ticks honor the configured
 // interval.
 func (p *Poller) Run(ctx context.Context) {
-	ctx, p.stop = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	// Publish stop + done under doneM: Stop() may be called (from a
+	// concurrent goroutine) before or during Run's startup, and both
+	// fields are read there. Guarding only done left a race on stop.
 	p.doneM.Lock()
+	p.stop = cancel
 	p.done = make(chan struct{})
 	p.doneM.Unlock()
 	defer close(p.done)
@@ -137,12 +141,13 @@ func (p *Poller) Run(ctx context.Context) {
 // Stop signals Run to exit and waits up to 5 seconds for it. Safe to
 // call multiple times.
 func (p *Poller) Stop() {
-	if p.stop != nil {
-		p.stop()
-	}
 	p.doneM.Lock()
+	stop := p.stop
 	d := p.done
 	p.doneM.Unlock()
+	if stop != nil {
+		stop()
+	}
 	if d == nil {
 		return
 	}

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1235,16 +1235,22 @@ func TestTick_AutoImportSyncRemovesVanished(t *testing.T) {
 		OnSave: func() error { saveCalls++; return nil },
 	})
 
-	p.tick(context.Background())
+	// Removal is subject to the absence grace window (hysteresis), so the
+	// container must be missing across syncRemovalGraceTicks scans before
+	// sync removes it. Tick through the grace; only the final tick commits
+	// the removal (one Save).
+	for i := 0; i < syncRemovalGraceTicks; i++ {
+		p.tick(context.Background())
+	}
 
 	if findAppByKey(cfg, "label:gone") != nil {
-		t.Errorf("sync mode should remove vanished auto app; apps=%+v", cfg.Apps)
+		t.Errorf("sync mode should remove vanished auto app after the grace period; apps=%+v", cfg.Apps)
 	}
 	if findSiteByKey(cfg, "label:gone") != nil {
-		t.Errorf("sync mode should remove the vanished gateway site; sites=%+v", cfg.Server.GatewaySites)
+		t.Errorf("sync mode should remove the vanished gateway site after the grace period; sites=%+v", cfg.Server.GatewaySites)
 	}
 	if saveCalls != 1 {
-		t.Errorf("Save called %d times, want 1", saveCalls)
+		t.Errorf("Save called %d times, want 1 (removal commits once, at the end of the grace window)", saveCalls)
 	}
 }
 
@@ -1429,7 +1435,8 @@ func TestTick_GatewaySyncReconcile_AppURLStable_SiteRefreshes(t *testing.T) {
 // app and the gateway site must be restored to their prior state.
 func TestTick_AutoImportRollbackOnSaveFailure_Gateway(t *testing.T) {
 	// Empty daemon: the tracked gateway container has vanished, so sync mode
-	// plans a removal of both the app and its sibling site.
+	// plans a removal of both the app and its sibling site once the absence
+	// grace window elapses.
 	set := []ContainerSummary{}
 	socket, cleanup := mutableDaemonForPoller(t, &set)
 	defer cleanup()
@@ -1457,7 +1464,11 @@ func TestTick_AutoImportRollbackOnSaveFailure_Gateway(t *testing.T) {
 		OnSave: func() error { return errors.New("synthetic save failure") },
 	})
 
-	p.tick(context.Background())
+	// Tick through the grace window; the final tick actually attempts the
+	// removal, whose save fails and must roll back.
+	for i := 0; i < syncRemovalGraceTicks; i++ {
+		p.tick(context.Background())
+	}
 
 	if findAppByKey(cfg, "label:sonarr-auto") == nil {
 		t.Errorf("save failure must roll back the removal; app missing, apps=%+v", cfg.Apps)
@@ -1485,6 +1496,46 @@ func gwSonarr() ContainerSummary {
 // proceeds past the URL-refresh pass) but the self-detect scan is blocked
 // (network_filter empty + no self-inspect endpoint served), so
 // svc.Scan() returns ScanBlocked with no suggestions.
+// TestTick_AutoImportSync_TransientEmptyScanDefersRemoval: a successful
+// scan that returns an empty container list is ambiguous (a transient
+// daemon hiccup looks identical to "all containers genuinely removed").
+// Removal must be deferred until the absence persists for the grace
+// window, so one empty scan can't wipe every auto-imported entry.
+func TestTick_AutoImportSync_TransientEmptyScanDefersRemoval(t *testing.T) {
+	set := []ContainerSummary{} // daemon is up (200) but the list is empty
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportSync)
+	cfg.Apps = []config.AppConfig{{
+		Name: "Sonarr", URL: "https://sonarr.example.com",
+		DockerKey: "label:sonarr-auto", DockerEndpoint: "unix://" + socket,
+		DockerStrategy: "container_ip", DockerAutoImported: true,
+	}}
+	cfg.Server.GatewaySites = []config.GatewaySite{{
+		Domain: "sonarr.example.com", BackendURL: "http://10.0.0.5:8989",
+		DockerKey: "label:sonarr-auto", DockerEndpoint: "unix://" + socket,
+	}}
+	pxy := newProxyForBatchTest([]proxy.GatewaySite{}, func() error { return nil })
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy, OnSave: func() error { return nil }})
+
+	// One empty scan must not remove anything.
+	p.tick(context.Background())
+	if findAppByKey(cfg, "label:sonarr-auto") == nil || findSiteByKey(cfg, "label:sonarr-auto") == nil {
+		t.Fatal("a single empty scan must not remove the auto-imported entry")
+	}
+
+	// Sustained absence past the grace window removes it (mirror upheld).
+	for i := 0; i < syncRemovalGraceTicks; i++ {
+		p.tick(context.Background())
+	}
+	if findAppByKey(cfg, "label:sonarr-auto") != nil || findSiteByKey(cfg, "label:sonarr-auto") != nil {
+		t.Error("sustained absence should remove the auto-imported entry after the grace period")
+	}
+}
+
 func TestTick_AutoImportSync_ScanFailureDoesNotDeleteApps(t *testing.T) {
 	set := []ContainerSummary{} // container list succeeds but is empty
 	socket, cleanup := mutableDaemonForPoller(t, &set)

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1828,3 +1828,41 @@ func TestPoller_StopConcurrentWithRun(t *testing.T) {
 	cancel()
 	<-done
 }
+
+// TestTick_DaemonFailureDedupesUntilRecovery: repeated ListContainers
+// failures set daemonDown once (so the warning is logged once, not every
+// tick), and a later success clears it (logging recovery once).
+func TestTick_DaemonFailureDedupesUntilRecovery(t *testing.T) {
+	failing := true
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_ping", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/v1.41/containers/json", func(w http.ResponseWriter, _ *http.Request) {
+		if failing {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]ContainerSummary{})
+	})
+	socket, cleanup := fakeDockerOverUnix(t, mux)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportOff)
+	cfg.Apps = []config.AppConfig{{Name: "a", DockerKey: "label:a", DockerEndpoint: "unix://" + socket}}
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	p := NewPoller(PollerDeps{Config: cfg, ConfigMu: &mu, Service: svc, OnSave: func() error { return nil }})
+
+	p.tick(context.Background())
+	if !p.daemonDown {
+		t.Fatal("first ListContainers failure must set daemonDown")
+	}
+	p.tick(context.Background())
+	if !p.daemonDown {
+		t.Fatal("daemonDown must stay set across repeated failures")
+	}
+	failing = false
+	p.tick(context.Background())
+	if p.daemonDown {
+		t.Error("a successful listing must clear daemonDown (recovery)")
+	}
+}

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1891,3 +1891,74 @@ func TestDedupeDesiredNames(t *testing.T) {
 		t.Errorf("winner should be the lowest DockerKey (label:a), got %q", names["Sonarr"])
 	}
 }
+
+// TestService_ReconfigureReachesPoller proves the runtime-config fix: the
+// poller and the service share one *Service, so reconfiguring it in place
+// (enable discovery / change endpoint at runtime) reaches the poller
+// without a restart -- rather than only the discovery handler seeing a
+// freshly-swapped pointer.
+func TestService_ReconfigureReachesPoller(t *testing.T) {
+	set := []ContainerSummary{labeledSonarr()}
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	// Service starts disabled (no client); the poller shares it.
+	svc := NewService(&config.DiscoveryDockerConfig{Enabled: false})
+	if svc.currentClient() != nil {
+		t.Fatal("disabled service must have no client")
+	}
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportAdd)
+	var mu sync.RWMutex
+	p := NewPoller(PollerDeps{Config: cfg, ConfigMu: &mu, Service: svc, OnSave: func() error { return nil }})
+
+	p.tick(context.Background())
+	if len(cfg.Apps) != 0 {
+		t.Fatalf("poller must not import while the service has no client; apps=%+v", cfg.Apps)
+	}
+
+	// Enable at runtime by reconfiguring the SAME service pointer.
+	svc.Reconfigure(dockerCfg)
+	if svc.currentClient() == nil {
+		t.Fatal("reconfigured (enabled) service must have a client")
+	}
+	p.tick(context.Background())
+	if findAppByKey(cfg, "label:sonarr-auto") == nil {
+		t.Error("after Reconfigure the poller must pick up the new client and import")
+	}
+
+	// Disabling clears the client again.
+	svc.Reconfigure(&config.DiscoveryDockerConfig{Enabled: false})
+	if svc.currentClient() != nil {
+		t.Error("disabling must clear the client")
+	}
+}
+
+// TestService_ReconfigureConcurrentWithReaders validates the lock pairing
+// between Reconfigure (writes cfg/client under s.mu) and readers like
+// currentClient/Status. Meaningful under -race. Uses empty-endpoint
+// configs so no socket probe runs (kept fast).
+func TestService_ReconfigureConcurrentWithReaders(t *testing.T) {
+	svc := NewService(&config.DiscoveryDockerConfig{Enabled: false})
+	a := config.DiscoveryDockerConfig{Enabled: true, Endpoint: ""}
+	b := config.DiscoveryDockerConfig{Enabled: false}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			if i%2 == 0 {
+				svc.Reconfigure(&a)
+			} else {
+				svc.Reconfigure(&b)
+			}
+		}
+		close(done)
+	}()
+	for {
+		select {
+		case <-done:
+			return
+		default:
+			_ = svc.currentClient()
+			_ = svc.Status(context.Background())
+		}
+	}
+}

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1867,16 +1867,15 @@ func TestTick_DaemonFailureDedupesUntilRecovery(t *testing.T) {
 	}
 }
 
-// TestDedupeDesiredNames: two containers resolving to the same app name
-// collapse to one entry, with a deterministic winner (lowest DockerKey),
-// so auto-import never writes duplicate app names.
+// TestDedupeDesiredNames: two fresh containers resolving to the same name
+// collapse to one entry, winner = lowest DockerKey.
 func TestDedupeDesiredNames(t *testing.T) {
 	in := []Desired{
 		{App: config.AppConfig{Name: "Sonarr", DockerKey: "label:b"}},
 		{App: config.AppConfig{Name: "Radarr", DockerKey: "label:c"}},
 		{App: config.AppConfig{Name: "Sonarr", DockerKey: "label:a"}},
 	}
-	out := dedupeDesiredNames(in)
+	out := dedupeDesiredNames(in, nil)
 	if len(out) != 2 {
 		t.Fatalf("want 2 unique names, got %d: %+v", len(out), out)
 	}
@@ -1889,6 +1888,38 @@ func TestDedupeDesiredNames(t *testing.T) {
 	}
 	if names["Sonarr"] != "label:a" {
 		t.Errorf("winner should be the lowest DockerKey (label:a), got %q", names["Sonarr"])
+	}
+}
+
+// TestDedupeDesiredNames_RespectsIncumbent: a name already held in the
+// config by one container must not be handed to a different (even
+// lower-key) container. Otherwise the new one would be Added immediately
+// while the incumbent's removal is deferred by hysteresis, briefly
+// producing two apps of the same name.
+func TestDedupeDesiredNames_RespectsIncumbent(t *testing.T) {
+	current := []config.AppConfig{
+		{Name: "Sonarr", DockerKey: "label:b", DockerAutoImported: true},
+		{Name: "Grafana"}, // manual app, no docker key
+	}
+	in := []Desired{
+		{App: config.AppConfig{Name: "Sonarr", DockerKey: "label:a"}},  // challenger, lower key
+		{App: config.AppConfig{Name: "Sonarr", DockerKey: "label:b"}},  // incumbent, still present
+		{App: config.AppConfig{Name: "Grafana", DockerKey: "label:g"}}, // collides with a manual app
+	}
+	out := dedupeDesiredNames(in, current)
+
+	byName := map[string]string{}
+	for _, e := range out {
+		if prev, dup := byName[e.App.Name]; dup {
+			t.Errorf("duplicate name %q (keys %s and %s)", e.App.Name, prev, e.App.DockerKey)
+		}
+		byName[e.App.Name] = e.App.DockerKey
+	}
+	if byName["Sonarr"] != "label:b" {
+		t.Errorf("incumbent label:b must keep the Sonarr name, got %q", byName["Sonarr"])
+	}
+	if _, ok := byName["Grafana"]; ok {
+		t.Errorf("a name held by a manual app must not be taken by an auto-import")
 	}
 }
 

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1477,6 +1477,56 @@ func gwSonarr() ContainerSummary {
 	return c
 }
 
+// TestTick_AutoImportSync_ScanFailureDoesNotDeleteApps is a regression
+// guard for a data-loss bug: in sync mode a failed/blocked scan produced
+// an empty desired set, and Reconcile then treated every auto-imported
+// app as "vanished" and deleted it. A transient daemon hiccup must never
+// wipe the tracked apps. Here the container list succeeds (so the tick
+// proceeds past the URL-refresh pass) but the self-detect scan is blocked
+// (network_filter empty + no self-inspect endpoint served), so
+// svc.Scan() returns ScanBlocked with no suggestions.
+func TestTick_AutoImportSync_ScanFailureDoesNotDeleteApps(t *testing.T) {
+	set := []ContainerSummary{} // container list succeeds but is empty
+	socket, cleanup := mutableDaemonForPoller(t, &set)
+	defer cleanup()
+
+	cfg, dockerCfg := autoImportCfg(socket, config.AutoImportSync)
+	// Empty network_filter forces the self-detect path, which is blocked
+	// in the test env (the fake daemon serves no self-inspect endpoint).
+	dockerCfg.NetworkFilter = ""
+	cfg.Discovery.Docker.NetworkFilter = ""
+	// Pre-existing auto-imported app + its gateway site.
+	cfg.Apps = []config.AppConfig{{
+		Name: "Sonarr", URL: "https://sonarr.example.com",
+		DockerKey: "label:sonarr-auto", DockerAutoImported: true,
+	}}
+	cfg.Server.GatewaySites = []config.GatewaySite{{
+		Domain: "sonarr.example.com", BackendURL: "http://10.0.0.5:8989",
+		DockerKey: "label:sonarr-auto",
+	}}
+	pxy := newProxyForBatchTest([]proxy.GatewaySite{}, func() error { return nil })
+
+	var mu sync.RWMutex
+	svc := NewService(dockerCfg)
+	saveCalls := 0
+	p := NewPoller(PollerDeps{
+		Config: cfg, ConfigMu: &mu, Service: svc, Proxy: pxy,
+		OnSave: func() error { saveCalls++; return nil },
+	})
+
+	p.tick(context.Background())
+
+	if findAppByKey(cfg, "label:sonarr-auto") == nil {
+		t.Fatal("scan failure must NOT delete the auto-imported app")
+	}
+	if findSiteByKey(cfg, "label:sonarr-auto") == nil {
+		t.Fatal("scan failure must NOT delete the auto-imported gateway site")
+	}
+	if saveCalls != 0 {
+		t.Errorf("no config change expected on a blocked scan; Save called %d times", saveCalls)
+	}
+}
+
 func TestTick_AutoImportAdd_GatewaySite(t *testing.T) {
 	set := []ContainerSummary{gwSonarr()}
 	socket, cleanup := mutableDaemonForPoller(t, &set)

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1866,3 +1866,28 @@ func TestTick_DaemonFailureDedupesUntilRecovery(t *testing.T) {
 		t.Error("a successful listing must clear daemonDown (recovery)")
 	}
 }
+
+// TestDedupeDesiredNames: two containers resolving to the same app name
+// collapse to one entry, with a deterministic winner (lowest DockerKey),
+// so auto-import never writes duplicate app names.
+func TestDedupeDesiredNames(t *testing.T) {
+	in := []Desired{
+		{App: config.AppConfig{Name: "Sonarr", DockerKey: "label:b"}},
+		{App: config.AppConfig{Name: "Radarr", DockerKey: "label:c"}},
+		{App: config.AppConfig{Name: "Sonarr", DockerKey: "label:a"}},
+	}
+	out := dedupeDesiredNames(in)
+	if len(out) != 2 {
+		t.Fatalf("want 2 unique names, got %d: %+v", len(out), out)
+	}
+	names := map[string]string{}
+	for _, e := range out {
+		if _, dup := names[e.App.Name]; dup {
+			t.Errorf("duplicate name survived: %q", e.App.Name)
+		}
+		names[e.App.Name] = e.App.DockerKey
+	}
+	if names["Sonarr"] != "label:a" {
+		t.Errorf("winner should be the lowest DockerKey (label:a), got %q", names["Sonarr"])
+	}
+}

--- a/internal/discovery/poller_test.go
+++ b/internal/discovery/poller_test.go
@@ -1809,3 +1809,22 @@ func TestTick_AutoImportSkipsSelfAndNetworkFiltered(t *testing.T) {
 		t.Errorf("media-network sonarr should import; apps=%+v", cfg.Apps)
 	}
 }
+
+// TestPoller_StopConcurrentWithRun exercises Stop racing Run's startup,
+// where both touch p.stop/p.done. Meaningful under -race. Discovery is
+// disabled so tick() returns immediately and Run is a no-op loop.
+func TestPoller_StopConcurrentWithRun(t *testing.T) {
+	var mu sync.RWMutex
+	p := NewPoller(PollerDeps{
+		Config:   &config.Config{}, // discovery disabled -> tick() returns early
+		ConfigMu: &mu,
+		Service:  NewService(&config.DiscoveryDockerConfig{}),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { p.Run(ctx); close(done) }()
+	p.Stop()
+	cancel()
+	<-done
+}

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -113,13 +113,25 @@ func (h *APIHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 func (h *APIHandler) ExportConfig(w http.ResponseWriter, r *http.Request) {
 	h.mu.RLock()
 	cfg := *h.config
-	h.mu.RUnlock()
-
-	// Deep-copy slices that will be mutated to avoid writing through the
-	// shared backing array into the live config.
+	// Copy the slices we will read during the (unlocked) marshal off the
+	// live backing arrays. The poller and UpdateApp mutate Apps/Groups/
+	// GatewaySites elements in place under the write lock, so marshalling
+	// the shared arrays after RUnlock is a data race. Copying under the
+	// lock is safe (RLock excludes the writer); the marshal then runs on
+	// our private arrays. Users additionally gets its secrets stripped.
 	users := make([]config.UserConfig, len(cfg.Auth.Users))
 	copy(users, cfg.Auth.Users)
 	cfg.Auth.Users = users
+	apps := make([]config.AppConfig, len(cfg.Apps))
+	copy(apps, cfg.Apps)
+	cfg.Apps = apps
+	groups := make([]config.GroupConfig, len(cfg.Groups))
+	copy(groups, cfg.Groups)
+	cfg.Groups = groups
+	sites := make([]config.GatewaySite, len(cfg.Server.GatewaySites))
+	copy(sites, cfg.Server.GatewaySites)
+	cfg.Server.GatewaySites = sites
+	h.mu.RUnlock()
 
 	// Strip sensitive auth data
 	for i := range cfg.Auth.Users {

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -722,6 +722,14 @@ func (h *APIHandler) CreateApp(w http.ResponseWriter, r *http.Request) {
 	newApp := clientAppToConfig(&clientApp)
 	newApp.Order = len(h.config.Apps) // Add at end
 
+	// Validate before persisting: Config.Save does not validate, so an
+	// invalid http_action would be written to disk and only rejected on
+	// the next boot's Load, taking the whole config down with it.
+	if err := config.ValidateApp(&newApp); err != nil {
+		respondError(w, r, http.StatusBadRequest, "Invalid app: "+err.Error())
+		return
+	}
+
 	priorApps := append([]config.AppConfig(nil), h.config.Apps...)
 	h.config.Apps = append(h.config.Apps, newApp)
 
@@ -772,6 +780,13 @@ func (h *APIHandler) UpdateApp(w http.ResponseWriter, r *http.Request, name stri
 		logging.Audit("Docker tracking auto-detached on URL change",
 			"kind", "app", "name", updated.Name,
 			"previous_key", detachKey)
+	}
+
+	// Validate before persisting (see CreateApp): reject an invalid
+	// http_action up front rather than writing it to disk.
+	if err := config.ValidateApp(&updated); err != nil {
+		respondError(w, r, http.StatusBadRequest, "Invalid app: "+err.Error())
+		return
 	}
 
 	priorApps := append([]config.AppConfig(nil), h.config.Apps...)

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -59,10 +59,23 @@ func (h *APIHandler) SetDockerLifecycleDeps(svc DockerServiceAPI, hub DockerHubB
 // NewAPIHandler creates a new API handler
 func NewAPIHandler(cfg *config.Config, configPath string, mu *sync.RWMutex) *APIHandler {
 	return &APIHandler{
-		config:       cfg,
-		configPath:   configPath,
-		mu:           mu,
-		actionClient: &http.Client{Timeout: 10 * time.Second},
+		config:     cfg,
+		configPath: configPath,
+		mu:         mu,
+		actionClient: &http.Client{
+			Timeout: 10 * time.Second,
+			// Do not follow redirects. http_action targets are admin-
+			// configured (a private-IP homelab webhook is legitimate, so
+			// the initial request is intentionally not IP-filtered), but a
+			// redirect Location is controlled by the target server -- an
+			// external target that 302s to a link-local/loopback address
+			// would turn this into a server-side SSRF probe. Returning the
+			// 3xx as-is keeps the direct-hit use case working while closing
+			// the redirect vector.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 	}
 }
 

--- a/internal/handlers/api_test.go
+++ b/internal/handlers/api_test.go
@@ -2852,3 +2852,31 @@ func TestBuildClientConfigResponseWithAuth(t *testing.T) {
 		}
 	})
 }
+
+// TestExportConfig_NoRaceWithConcurrentAppMutation guards the config
+// export against a data race: ExportConfig takes a shallow copy of the
+// config and marshals it after releasing the lock, so the marshal read of
+// cfg.Apps[i] must not alias a slice the poller/UpdateApp mutate in place.
+// Fails under -race unless Apps/Groups/GatewaySites are copied under the
+// lock (like Users already is).
+func TestExportConfig_NoRaceWithConcurrentAppMutation(t *testing.T) {
+	cfg := &config.Config{Apps: []config.AppConfig{{Name: "a", URL: "http://a"}}}
+	var mu sync.RWMutex
+	h := NewAPIHandler(cfg, "", &mu)
+
+	urls := []string{"http://a-0", "http://a-1"}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 2000; i++ {
+			mu.Lock()
+			cfg.Apps[0].URL = urls[i%2]
+			mu.Unlock()
+		}
+		close(done)
+	}()
+	for i := 0; i < 2000; i++ {
+		w := httptest.NewRecorder()
+		h.ExportConfig(w, httptest.NewRequest(http.MethodGet, "/api/config/export", nil))
+	}
+	<-done
+}

--- a/internal/handlers/api_test.go
+++ b/internal/handlers/api_test.go
@@ -1443,6 +1443,71 @@ func TestSanitizeApp(t *testing.T) {
 
 // Tests for save-failure error paths using an invalid configPath.
 // /dev/null/impossible is guaranteed to fail because /dev/null is a file, not a directory.
+// TestCreateApp_RejectsInvalidHTTPAction guards that the per-app create
+// path validates an http_action app before persisting. Without this,
+// clientAppToConfig + Save writes a structurally invalid action to disk
+// (Save does not validate), and the next boot's Load validation rejects
+// the whole config -- turning a bad single-app edit into a startup
+// failure. The handler must reject it up front with a 400.
+func TestCreateApp_RejectsInvalidHTTPAction(t *testing.T) {
+	cfg := createTestConfig()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewAPIHandler(cfg, tmpFile.Name(), &sync.RWMutex{})
+	before := len(cfg.Apps)
+
+	body, _ := json.Marshal(ClientAppConfig{
+		Name:             "BadWebhook",
+		URL:              "https://hook.local/fire",
+		OpenMode:         "http_action",
+		HTTPActionMethod: "TRACE", // not in the allowed verb set
+		Enabled:          true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/apps", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.CreateApp(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for invalid http_action, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(cfg.Apps) != before {
+		t.Errorf("invalid app must not be added: apps went from %d to %d", before, len(cfg.Apps))
+	}
+}
+
+// TestUpdateApp_RejectsInvalidHTTPAction is the update-path counterpart:
+// an edit that turns an app into an invalid http_action must be rejected
+// and must not mutate the stored app.
+func TestUpdateApp_RejectsInvalidHTTPAction(t *testing.T) {
+	cfg := createTestConfig()
+	tmpFile, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewAPIHandler(cfg, tmpFile.Name(), &sync.RWMutex{})
+	origURL := cfg.Apps[0].URL
+
+	body, _ := json.Marshal(ClientAppConfig{
+		Name:             cfg.Apps[0].Name,
+		URL:              "", // http_action requires a url
+		OpenMode:         "http_action",
+		HTTPActionMethod: "POST",
+		Enabled:          true,
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/apps/"+cfg.Apps[0].Name, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.UpdateApp(w, req, cfg.Apps[0].Name)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for invalid http_action, got %d: %s", w.Code, w.Body.String())
+	}
+	if cfg.Apps[0].URL != origURL {
+		t.Errorf("stored app must be unchanged on rejected update: URL is now %q", cfg.Apps[0].URL)
+	}
+}
+
 func TestCreateAppSaveFails(t *testing.T) {
 	cfg := createTestConfig()
 	handler := NewAPIHandler(cfg, "/dev/null/impossible/config.yaml", &sync.RWMutex{})

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -774,6 +774,16 @@ func (h *AuthHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Revoke the deleted user's live sessions so the account cannot keep
+	// acting (with its captured role) until the session's absolute expiry.
+	// Mirrors ChangePassword. Keyed by user ID (== username for builtin
+	// users). Best-effort: the user is already gone from the store, so a
+	// lingering session would fail the GetByID lookup anyway, but this
+	// closes the userFromSession fallback path immediately.
+	if prev != nil {
+		h.sessionStore.DeleteByUserID(prev.ID, "")
+	}
+
 	logging.From(r.Context()).Info("User deleted", "source", "audit", "user", username)
 	sendJSON(w, http.StatusOK, map[string]bool{"success": true})
 }

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -1002,7 +1002,7 @@ func (h *AuthHandler) GenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 // rather than a clobber. A save failure rolls back the in-memory change
 // and is logged; the next successful verify retries.
 func (h *AuthHandler) UpgradeAPIKeyHash(oldHash, newHash string) {
-	if oldHash == "" || newHash == "" || oldHash == newHash {
+	if h.config == nil || oldHash == "" || newHash == "" || oldHash == newHash {
 		return
 	}
 	h.configMu.Lock()

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -281,6 +281,15 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Carry the user's group memberships on the session so gateway sites
+	// with an allowed_groups gate accept builtin users. The gateway
+	// forward-auth check (sessionInAllowedGroups) reads groups from
+	// session.Data, which the OIDC path populates too; without this a
+	// builtin member of an allowed group is denied at a require_auth gate.
+	if len(user.Groups) > 0 {
+		session.Data["groups"] = user.Groups
+	}
+
 	// Set session cookie
 	h.sessionStore.SetCookie(w, session)
 	logging.From(r.Context()).Info("User logged in", "source", "audit", "user", user.Username)

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/mescon/muximux/v3/internal/auth"
 	"github.com/mescon/muximux/v3/internal/config"
 	"github.com/mescon/muximux/v3/internal/logging"
@@ -904,11 +902,6 @@ func (h *AuthHandler) UpdateAuthMethod(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// apiKeyTargetCost matches the project-wide bcrypt cost used for user
-// passwords (auth.bcryptTargetCost). Hardcoded rather than imported to
-// avoid widening the auth package's exported surface for one constant.
-const apiKeyTargetCost = 12
-
 // apiKeyByteLen is the random byte budget for a generated API key.
 // 32 bytes encoded as base64url is 43 chars; with the muximux_ prefix
 // the user-visible key is 51 characters.
@@ -946,15 +939,15 @@ func (h *AuthHandler) GenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 	plaintext := "muximux_" + base64.RawURLEncoding.EncodeToString(raw)
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), apiKeyTargetCost)
-	if err != nil {
-		respondError(w, r, http.StatusInternalServerError, "Failed to hash key", "source", "auth", "error", err)
-		return
-	}
+	// SHA-256, not bcrypt: an API key is a high-entropy token, so a fast
+	// constant-time hash is equally brute-force-resistant without bcrypt's
+	// per-verify CPU cost (an unauthenticated DoS vector on the bypass
+	// path). Existing bcrypt hashes still verify; this rotation migrates.
+	hash := auth.HashAPIKey(plaintext)
 
 	h.configMu.Lock()
 	prev := h.config.Auth.APIKeyHash
-	h.config.Auth.APIKeyHash = string(hash)
+	h.config.Auth.APIKeyHash = hash
 	saveErr := h.config.Save(h.configPath)
 	if saveErr != nil {
 		// Roll back the in-memory mutation so a failed disk write does

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -992,6 +992,36 @@ func (h *AuthHandler) GenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// UpgradeAPIKeyHash migrates a legacy bcrypt api_key_hash to the fast
+// sha256: form after the auth middleware verifies the key against the
+// legacy hash. It is wired as the middleware's onAPIKeyUpgrade hook and
+// runs off the request goroutine. The compare-and-swap on oldHash makes
+// it safe and idempotent: it only writes when the stored hash is still
+// exactly the legacy value the middleware verified against, so a
+// concurrent rotation (or a second concurrent legacy request) is a no-op
+// rather than a clobber. A save failure rolls back the in-memory change
+// and is logged; the next successful verify retries.
+func (h *AuthHandler) UpgradeAPIKeyHash(oldHash, newHash string) {
+	if oldHash == "" || newHash == "" || oldHash == newHash {
+		return
+	}
+	h.configMu.Lock()
+	defer h.configMu.Unlock()
+	if h.config.Auth.APIKeyHash != oldHash {
+		// Rotated or already migrated since the verify; nothing to do.
+		return
+	}
+	h.config.Auth.APIKeyHash = newHash
+	if err := h.config.Save(h.configPath); err != nil {
+		h.config.Auth.APIKeyHash = oldHash
+		logging.Error("Legacy API key auto-upgrade rolled back due to save failure",
+			"source", "audit", "error", err)
+		return
+	}
+	h.refreshAuthSnapshotLocked()
+	logging.Audit("Legacy API key hash auto-upgraded to sha256 on use")
+}
+
 // DeleteAPIKey clears the configured API key. Bypass rules that
 // require the key (for example /api/appearance) immediately stop
 // authenticating with X-Api-Key once this returns. Admin only.

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -1054,6 +1054,43 @@ func TestUpdateUser(t *testing.T) {
 	})
 }
 
+// TestDeleteUser_RevokesSessions: deleting a user must invalidate their
+// live sessions. Otherwise the deleted account stays authenticated (and,
+// via userFromSession, keeps its captured role) until the session's
+// 7-day absolute expiry -- defeating deletion as an access-revocation
+// control. ChangePassword already does this; deletion must too.
+func TestDeleteUser_RevokesSessions(t *testing.T) {
+	handler, sessionStore := setupAuthTest(t)
+
+	hash, _ := auth.HashPassword("password123")
+	if err := handler.userStore.Add(&auth.User{
+		ID: "victim", Username: "victim", PasswordHash: hash, Role: "user",
+	}); err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	sess, err := sessionStore.Create("victim", "victim", "user")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if sessionStore.Get(sess.ID) == nil {
+		t.Fatal("precondition: victim session must exist")
+	}
+
+	currentUser := &auth.User{ID: "admin", Username: "admin", Role: "admin"}
+	req := httptest.NewRequest(http.MethodDelete, "/api/auth/users/victim", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ContextKeyUser, currentUser))
+	w := httptest.NewRecorder()
+
+	handler.DeleteUser(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if sessionStore.Get(sess.ID) != nil {
+		t.Error("deleting a user must revoke their active sessions")
+	}
+}
+
 func TestDeleteUser(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		handler, _ := setupAuthTest(t)

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/mescon/muximux/v3/internal/auth"
 	"github.com/mescon/muximux/v3/internal/config"
 )
@@ -1910,8 +1908,8 @@ func TestGenerateAPIKey_StoresHashAndReturnsPlaintextOnce(t *testing.T) {
 	if on.Auth.APIKeyHash == "" {
 		t.Fatal("APIKeyHash empty on disk after POST")
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(on.Auth.APIKeyHash), []byte(resp.Key)); err != nil {
-		t.Errorf("disk hash does not validate plaintext: %v", err)
+	if ok, _ := auth.VerifyAPIKey(resp.Key, on.Auth.APIKeyHash); !ok {
+		t.Errorf("disk hash does not validate the returned plaintext (hash=%q)", on.Auth.APIKeyHash)
 	}
 
 	// A second POST rotates the key and reports rotated=true.

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -1941,6 +1941,48 @@ func TestAPIKeyStatus_Unconfigured(t *testing.T) {
 	}
 }
 
+// TestUpgradeAPIKeyHash covers the opportunistic legacy-hash migration
+// hook: it upgrades and persists only when the stored hash still matches
+// the old (legacy) value the middleware verified against (compare-and-
+// swap), and is a no-op on mismatch or when already migrated.
+func TestUpgradeAPIKeyHash(t *testing.T) {
+	handler, configPath := setupAuthTestWithConfig(t)
+
+	legacy, err := auth.HashPassword("muximux_apikey") // bcrypt = legacy form
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	handler.config.Auth.APIKeyHash = legacy
+	if err := handler.config.Save(configPath); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+	newHash := auth.HashAPIKey("muximux_apikey")
+
+	// CAS mismatch: the stored hash is not the one we claim to have
+	// verified against -> no upgrade.
+	handler.UpgradeAPIKeyHash("sha256:stale", newHash)
+	if handler.config.Auth.APIKeyHash != legacy {
+		t.Fatalf("must not upgrade on oldHash mismatch: got %q", handler.config.Auth.APIKeyHash)
+	}
+
+	// CAS match: upgrades in memory and persists to disk.
+	handler.UpgradeAPIKeyHash(legacy, newHash)
+	if handler.config.Auth.APIKeyHash != newHash {
+		t.Fatalf("expected in-memory upgrade to sha256, got %q", handler.config.Auth.APIKeyHash)
+	}
+	on := loadConfigForTest(t, configPath)
+	if on.Auth.APIKeyHash != newHash {
+		t.Fatalf("upgrade not persisted: disk hash = %q", on.Auth.APIKeyHash)
+	}
+
+	// Idempotent: replaying the old (legacy) oldHash after migration is a
+	// no-op -- the stored hash is now sha256, not the legacy value.
+	handler.UpgradeAPIKeyHash(legacy, auth.HashAPIKey("someone-elses-key"))
+	if handler.config.Auth.APIKeyHash != newHash {
+		t.Fatalf("second upgrade should be a no-op, got %q", handler.config.Auth.APIKeyHash)
+	}
+}
+
 func TestGenerateAPIKey_StoresHashAndReturnsPlaintextOnce(t *testing.T) {
 	handler, configPath := setupAuthTestWithConfig(t)
 

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -45,6 +45,76 @@ func setupAuthTest(t *testing.T) (*AuthHandler, *auth.SessionStore) {
 	return handler, sessionStore
 }
 
+// TestLogin_PopulatesSessionGroups guards the gateway group gate against
+// fail-closed denial of builtin users. sessionInAllowedGroups reads a
+// user's groups from session.Data["groups"], which OIDC populates but the
+// builtin login path historically did not. A builtin user who is a member
+// of a gateway site's allowed_groups was therefore denied at a require_auth
+// gate. This asserts the builtin login now stores the user's groups in the
+// session, and that a group-gated site accepts the resulting session.
+func TestLogin_PopulatesSessionGroups(t *testing.T) {
+	sessionStore := auth.NewSessionStore("muximux_session", 24*time.Hour, false)
+	userStore := auth.NewUserStore()
+
+	hash, err := auth.HashPassword("testpass123")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+	userStore.LoadFromConfig([]auth.UserConfig{
+		{
+			Username:     "member",
+			PasswordHash: hash,
+			Role:         "user",
+			Groups:       []string{"media", "admins"},
+		},
+	})
+	handler := NewAuthHandler(sessionStore, userStore, nil, "", nil, &sync.RWMutex{})
+
+	body, _ := json.Marshal(LoginRequest{ //nolint:gosec // test fixture
+		Username: "member",
+		Password: "testpass123",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.Login(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var sessionID string
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "muximux_session" {
+			sessionID = c.Value
+			break
+		}
+	}
+	if sessionID == "" {
+		t.Fatal("expected session cookie to be set")
+	}
+
+	sess := sessionStore.Get(sessionID)
+	if sess == nil {
+		t.Fatal("expected session to exist in store")
+	}
+	raw, ok := sess.Data["groups"]
+	if !ok {
+		t.Fatal("expected session.Data[\"groups\"] to be populated for builtin login")
+	}
+	groups, ok := raw.([]string)
+	if !ok {
+		t.Fatalf("expected groups to be []string, got %T", raw)
+	}
+	if len(groups) != 2 || groups[0] != "media" || groups[1] != "admins" {
+		t.Errorf("expected groups [media admins], got %v", groups)
+	}
+
+	// The gateway group gate must now accept this session.
+	if !sessionInAllowedGroups(sess, []string{"admins"}) {
+		t.Error("expected group-gated site to accept a builtin member of the group")
+	}
+}
+
 func TestLogin(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		handler, _ := setupAuthTest(t)

--- a/internal/handlers/discovery.go
+++ b/internal/handlers/discovery.go
@@ -215,13 +215,16 @@ func (h *DiscoveryHandler) UpdateDockerConfig(w http.ResponseWriter, r *http.Req
 	}
 	h.configMu.Unlock()
 
-	// Rebuild the service. NewService is cheap (no network calls)
-	// and returns a non-nil pointer even when the new config is
-	// disabled or has a structurally bad endpoint.
-	newService := discovery.NewService(&newCfg)
-	h.serviceMu.Lock()
-	h.service = newService
-	h.serviceMu.Unlock()
+	// Reconfigure the shared service IN PLACE. The same *Service is held
+	// by the poller and the lifecycle op closures, so rebuilding it in
+	// place (rather than swapping only this handler's pointer) makes the
+	// change take effect everywhere without a restart -- enabling
+	// discovery, changing the endpoint, etc. all reach the poller and
+	// lifecycle handlers on the next tick / action.
+	h.serviceMu.RLock()
+	svc := h.service
+	h.serviceMu.RUnlock()
+	svc.Reconfigure(&newCfg)
 
 	logging.Audit("Discovery config updated",
 		"endpoint", newCfg.Endpoint,
@@ -229,7 +232,7 @@ func (h *DiscoveryHandler) UpdateDockerConfig(w http.ResponseWriter, r *http.Req
 		"enabled", newCfg.Enabled)
 
 	// Return the fresh status so the UI can update without a follow-up GET.
-	sendJSON(w, http.StatusOK, newService.Status(r.Context()))
+	sendJSON(w, http.StatusOK, svc.Status(r.Context()))
 }
 
 // ScanDocker handles GET /api/discovery/docker/scan. Walks the

--- a/internal/handlers/discovery.go
+++ b/internal/handlers/discovery.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mescon/muximux/v3/internal/auth"
 	"github.com/mescon/muximux/v3/internal/config"
 	"github.com/mescon/muximux/v3/internal/discovery"
 	"github.com/mescon/muximux/v3/internal/logging"
@@ -156,7 +157,35 @@ func (h *DiscoveryHandler) GetDockerStateMap(w http.ResponseWriter, r *http.Requ
 		sendJSON(w, http.StatusOK, map[string]discovery.DockerState{})
 		return
 	}
-	sendJSON(w, http.StatusOK, svc.DockerStateSnapshot())
+
+	// Filter to apps the caller is allowed to see. The state map is keyed
+	// by app name and, without this, exposed the container status, image,
+	// uptime, and restart count of every tracked app to any authenticated
+	// user -- including apps hidden from them by min_role / allowed_groups.
+	// This mirrors the per-app gate the lifecycle (control) handlers apply.
+	// Fail closed: a request with no user in context sees nothing.
+	full := svc.DockerStateSnapshot()
+	user := auth.GetUserFromContext(r.Context())
+	if user == nil {
+		sendJSON(w, http.StatusOK, map[string]discovery.DockerState{})
+		return
+	}
+	h.configMu.RLock()
+	accessible := make(map[string]bool, len(h.config.Apps))
+	for i := range h.config.Apps {
+		if appAccessible(user, &h.config.Apps[i]) {
+			accessible[h.config.Apps[i].Name] = true
+		}
+	}
+	h.configMu.RUnlock()
+
+	visible := make(map[string]discovery.DockerState, len(full))
+	for name, st := range full {
+		if accessible[name] {
+			visible[name] = st
+		}
+	}
+	sendJSON(w, http.StatusOK, visible)
 }
 
 // UpdateDockerConfig handles PUT /api/discovery/docker/config. The

--- a/internal/handlers/discovery_test.go
+++ b/internal/handlers/discovery_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/mescon/muximux/v3/internal/auth"
 	"github.com/mescon/muximux/v3/internal/config"
 	"github.com/mescon/muximux/v3/internal/discovery"
 )
@@ -455,13 +456,14 @@ func TestGetDockerStatus_IncludesSocketWritableAndLifecycle(t *testing.T) {
 }
 
 func TestGetDockerStateMap_ReturnsCachedState(t *testing.T) {
-	cfg := &config.Config{}
+	cfg := &config.Config{Apps: []config.AppConfig{{Name: "sonarr"}}}
 	cfg.Discovery.Docker.Enabled = true
 	svc := discovery.NewService(&cfg.Discovery.Docker)
 	svc.SetDockerStateForApp("sonarr", &discovery.DockerState{Status: "running", Health: "healthy", Image: "img"})
 
 	h := NewDiscoveryHandler(svc, cfg, "/tmp/config.yaml", &sync.RWMutex{}, nil)
 	r := httptest.NewRequest(http.MethodGet, "/api/discovery/docker-state", nil)
+	r = r.WithContext(auth.WithUserContext(r.Context(), &auth.User{Username: "admin", Role: auth.RoleAdmin}))
 	w := httptest.NewRecorder()
 	h.GetDockerStateMap(w, r)
 
@@ -474,5 +476,52 @@ func TestGetDockerStateMap_ReturnsCachedState(t *testing.T) {
 	}
 	if body["sonarr"].Status != "running" {
 		t.Fatalf("want sonarr running, got %+v", body)
+	}
+}
+
+// TestGetDockerStateMap_FiltersByAppVisibility guards the read-side
+// companion to the #13 lifecycle access gate: the docker-state endpoint
+// must not expose container state for apps the requesting user is not
+// allowed to see (min_role / allowed_groups), or a non-admin could learn
+// the existence, image, and status of hidden apps.
+func TestGetDockerStateMap_FiltersByAppVisibility(t *testing.T) {
+	cfg := &config.Config{Apps: []config.AppConfig{
+		{Name: "public"},
+		{Name: "secret", AllowedGroups: []string{"admins"}},
+	}}
+	cfg.Discovery.Docker.Enabled = true
+	svc := discovery.NewService(&cfg.Discovery.Docker)
+	svc.SetDockerStateForApp("public", &discovery.DockerState{Status: "running", Image: "pub"})
+	svc.SetDockerStateForApp("secret", &discovery.DockerState{Status: "running", Image: "sec"})
+	h := NewDiscoveryHandler(svc, cfg, "/tmp/config.yaml", &sync.RWMutex{}, nil)
+
+	get := func(user *auth.User) map[string]discovery.DockerState {
+		r := httptest.NewRequest(http.MethodGet, "/api/discovery/docker-state", nil)
+		r = r.WithContext(auth.WithUserContext(r.Context(), user))
+		w := httptest.NewRecorder()
+		h.GetDockerStateMap(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
+		}
+		var body map[string]discovery.DockerState
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return body
+	}
+
+	// A non-admin with no groups sees only the unrestricted app.
+	nonAdmin := get(&auth.User{Username: "bob", Role: auth.RoleUser})
+	if _, ok := nonAdmin["public"]; !ok {
+		t.Error("non-admin should see the public app's state")
+	}
+	if _, ok := nonAdmin["secret"]; ok {
+		t.Error("non-admin must NOT see the group-restricted app's state")
+	}
+
+	// An admin sees everything.
+	admin := get(&auth.User{Username: "admin", Role: auth.RoleAdmin})
+	if len(admin) != 2 {
+		t.Errorf("admin should see both apps, got %d: %+v", len(admin), admin)
 	}
 }

--- a/internal/handlers/docker_lifecycle.go
+++ b/internal/handlers/docker_lifecycle.go
@@ -56,7 +56,7 @@ type DockerServiceAPI interface {
 // DockerHubBroadcaster is the narrow surface the lifecycle handlers
 // need from websocket.Hub. Same rationale as DockerServiceAPI.
 type DockerHubBroadcaster interface {
-	BroadcastDockerStateChanged(appName string, state *websocket.DockerStatePayload)
+	BroadcastDockerStateChanged(appName string, state *websocket.DockerStatePayload, restricted bool)
 }
 
 // dockerOp is the signature of the underlying daemon call. Start has
@@ -206,7 +206,11 @@ func (h *APIHandler) dockerAction(w http.ResponseWriter, r *http.Request, name, 
 
 	h.dockerService.SetDockerStateForApp(appName, &newState)
 	if h.dockerHub != nil {
-		h.dockerHub.BroadcastDockerStateChanged(appName, DockerStatePayloadFromState(&newState))
+		// A restricted app (min_role / allowed_groups) broadcasts its
+		// realtime state to admins only, matching the docker-state GET
+		// filter, so a non-admin can't learn a hidden app's state.
+		restricted := app.MinRole != "" || len(app.AllowedGroups) > 0
+		h.dockerHub.BroadcastDockerStateChanged(appName, DockerStatePayloadFromState(&newState), restricted)
 	}
 
 	logging.Audit("Docker lifecycle action succeeded",

--- a/internal/handlers/docker_lifecycle.go
+++ b/internal/handlers/docker_lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mescon/muximux/v3/internal/auth"
+	"github.com/mescon/muximux/v3/internal/config"
 	"github.com/mescon/muximux/v3/internal/discovery"
 	"github.com/mescon/muximux/v3/internal/logging"
 	"github.com/mescon/muximux/v3/internal/websocket"
@@ -119,12 +120,11 @@ func (h *APIHandler) dockerAction(w http.ResponseWriter, r *http.Request, name, 
 	}
 
 	h.mu.RLock()
-	var appName, dockerKey string
+	var app config.AppConfig
 	var found bool
 	for i := range h.config.Apps {
 		if h.config.Apps[i].Name == name {
-			appName = h.config.Apps[i].Name
-			dockerKey = h.config.Apps[i].DockerKey
+			app = h.config.Apps[i]
 			found = true
 			break
 		}
@@ -134,6 +134,19 @@ func (h *APIHandler) dockerAction(w http.ResponseWriter, r *http.Request, name, 
 		respondError(w, r, http.StatusNotFound, errAppNotFound)
 		return
 	}
+	// Per-app access gate: a user who clears the lifecycle gate above but
+	// is not allowed to SEE this app (its own min_role / allowed_groups)
+	// must not be able to control its container. The lifecycle gate alone
+	// governs the capability; this governs which apps it applies to.
+	// Mirrors http_action's appAccessible; admins bypass by role.
+	if !appAccessible(user, &app) {
+		logging.Audit("Docker lifecycle action denied",
+			"app", name, "action", action, "caller", caller, "reason", "app_access_denied")
+		respondError(w, r, http.StatusForbidden, errAccessDenied)
+		return
+	}
+	appName := app.Name
+	dockerKey := app.DockerKey
 	if dockerKey == "" {
 		respondError(w, r, http.StatusBadRequest, errAppNotDockerTracked)
 		return

--- a/internal/handlers/docker_lifecycle_test.go
+++ b/internal/handlers/docker_lifecycle_test.go
@@ -52,18 +52,20 @@ func (s *stubDockerService) SetDockerStateForApp(name string, st *discovery.Dock
 type stubDockerHub struct {
 	mu     sync.Mutex
 	events []struct {
-		AppName string
-		State   websocket.DockerStatePayload
+		AppName    string
+		State      websocket.DockerStatePayload
+		Restricted bool
 	}
 }
 
-func (h *stubDockerHub) BroadcastDockerStateChanged(appName string, state *websocket.DockerStatePayload) {
+func (h *stubDockerHub) BroadcastDockerStateChanged(appName string, state *websocket.DockerStatePayload, restricted bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.events = append(h.events, struct {
-		AppName string
-		State   websocket.DockerStatePayload
-	}{appName, *state})
+		AppName    string
+		State      websocket.DockerStatePayload
+		Restricted bool
+	}{appName, *state, restricted})
 }
 
 func newDockerLifecycleHandler(t *testing.T, cfg *config.DiscoveryDockerConfig, apps []config.AppConfig, svc *stubDockerService, hub *stubDockerHub, opFn func(context.Context, string) error) (*APIHandler, *http.Request) {

--- a/internal/handlers/docker_lifecycle_test.go
+++ b/internal/handlers/docker_lifecycle_test.go
@@ -344,6 +344,28 @@ func TestDockerStart_NotInAllowedGroup_Denied(t *testing.T) {
 	}
 }
 
+// TestDockerStart_AppAccessDenied_Denied: a user who clears the lifecycle
+// gate but is not allowed to SEE the app (its per-app min_role) must not
+// be able to control its container.
+func TestDockerStart_AppAccessDenied_Denied(t *testing.T) {
+	op := func(_ context.Context, _ string) error { t.Fatal("op must not run"); return nil }
+	svc := &stubDockerService{writable: true, resolvedIDs: map[string]string{"name:/sonarr": "abc123"}}
+	h, r := newDockerLifecycleHandler(t,
+		&config.DiscoveryDockerConfig{LifecycleEnabled: true, LifecycleMinRole: "user"},
+		// The app is admin-only; a plain user passes the lifecycle gate
+		// (min_role user) but must be blocked by the app's own min_role.
+		[]config.AppConfig{{Name: "sonarr", DockerKey: "name:/sonarr", MinRole: "admin"}},
+		svc, &stubDockerHub{}, op,
+	)
+	user := &auth.User{Username: "lowpriv", Role: auth.RoleUser}
+	r = r.WithContext(auth.WithUserContext(r.Context(), user))
+	w := httptest.NewRecorder()
+	h.DockerStart(w, r, "sonarr")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403 (per-app access denied), got %d", w.Code)
+	}
+}
+
 func TestDockerStart_AppNotDockerTracked(t *testing.T) {
 	op := func(_ context.Context, _ string) error { t.Fatal("op must not run"); return nil }
 	svc := &stubDockerService{writable: true}

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -3,31 +3,71 @@ package handlers
 import (
 	"net/http"
 	"strings"
+	"sync"
 
+	"github.com/mescon/muximux/v3/internal/auth"
+	"github.com/mescon/muximux/v3/internal/config"
 	"github.com/mescon/muximux/v3/internal/health"
 	"github.com/mescon/muximux/v3/internal/logging"
 )
 
 // HealthHandler handles health-related API requests
 type HealthHandler struct {
-	monitor *health.Monitor
+	monitor  *health.Monitor
+	config   *config.Config
+	configMu *sync.RWMutex
 }
 
-// NewHealthHandler creates a new health handler
-func NewHealthHandler(monitor *health.Monitor) *HealthHandler {
-	return &HealthHandler{monitor: monitor}
+// NewHealthHandler creates a new health handler. config/configMu are used to
+// filter health results by the caller's per-app visibility so a non-admin
+// cannot learn the existence or status of an app hidden from them by
+// min_role / allowed_groups (the same gate the app list and docker-state
+// endpoint apply).
+func NewHealthHandler(monitor *health.Monitor, cfg *config.Config, configMu *sync.RWMutex) *HealthHandler {
+	return &HealthHandler{monitor: monitor, config: cfg, configMu: configMu}
 }
 
-// GetAllHealth returns health status for all apps
+// appVisibleTo reports whether the given user may see the named app. An app
+// absent from config (an orphaned health entry) is treated as not visible.
+func (h *HealthHandler) appVisibleTo(user *auth.User, appName string) bool {
+	if user == nil {
+		return false
+	}
+	h.configMu.RLock()
+	defer h.configMu.RUnlock()
+	for i := range h.config.Apps {
+		if h.config.Apps[i].Name == appName {
+			return appAccessible(user, &h.config.Apps[i])
+		}
+	}
+	return false
+}
+
+// GetAllHealth returns health status for the apps the caller can see.
 func (h *HealthHandler) GetAllHealth(w http.ResponseWriter, r *http.Request) {
-	sendJSON(w, http.StatusOK, h.monitor.GetAllHealthSlice())
+	user := auth.GetUserFromContext(r.Context())
+	all := h.monitor.GetAllHealthSlice()
+	visible := make([]*health.AppHealth, 0, len(all))
+	for _, ah := range all {
+		if h.appVisibleTo(user, ah.Name) {
+			visible = append(visible, ah)
+		}
+	}
+	sendJSON(w, http.StatusOK, visible)
 }
 
-// GetAppHealth returns health status for a specific app
+// GetAppHealth returns health status for a specific app.
 func (h *HealthHandler) GetAppHealth(w http.ResponseWriter, r *http.Request) {
 	appName := extractAppName(r.URL.Path, "/health")
 	if appName == "" {
 		respondError(w, r, http.StatusBadRequest, "App name required")
+		return
+	}
+
+	// Gate before touching the monitor so a hidden app is indistinguishable
+	// from a nonexistent one (same 404, no existence oracle).
+	if !h.appVisibleTo(auth.GetUserFromContext(r.Context()), appName) {
+		respondError(w, r, http.StatusNotFound, errAppNotFound)
 		return
 	}
 
@@ -50,6 +90,11 @@ func (h *HealthHandler) CheckAppHealth(w http.ResponseWriter, r *http.Request) {
 	appName := extractAppName(r.URL.Path, "/health/check")
 	if appName == "" {
 		respondError(w, r, http.StatusBadRequest, "App name required")
+		return
+	}
+
+	if !h.appVisibleTo(auth.GetUserFromContext(r.Context()), appName) {
+		respondError(w, r, http.StatusNotFound, errAppNotFound)
 		return
 	}
 

--- a/internal/handlers/health_test.go
+++ b/internal/handlers/health_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/mescon/muximux/v3/internal/auth"
+	"github.com/mescon/muximux/v3/internal/config"
 	"github.com/mescon/muximux/v3/internal/health"
 )
 
@@ -21,14 +24,23 @@ func setupHealthTest(t *testing.T) *HealthHandler {
 		{Name: "radarr", URL: "http://localhost:7878", Enabled: true},
 	})
 
-	handler := NewHealthHandler(monitor)
+	cfg := &config.Config{Apps: []config.AppConfig{{Name: "sonarr"}, {Name: "radarr"}}}
+	handler := NewHealthHandler(monitor, cfg, &sync.RWMutex{})
 	return handler
+}
+
+// adminHealthReq builds a request whose context carries an admin user, as the
+// auth middleware does in production, so the handler's visibility filter has a
+// user to evaluate.
+func adminHealthReq(method, path string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	return req.WithContext(auth.WithUserContext(req.Context(), &auth.User{Username: "admin", Role: auth.RoleAdmin}))
 }
 
 func TestGetAllHealth(t *testing.T) {
 	handler := setupHealthTest(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	req := adminHealthReq(http.MethodGet, "/api/health")
 	w := httptest.NewRecorder()
 
 	handler.GetAllHealth(w, req)
@@ -59,11 +71,51 @@ func TestGetAllHealth(t *testing.T) {
 	}
 }
 
+// TestHealth_FiltersByAppVisibility guards that the health endpoints do not
+// expose an app hidden from the caller by min_role / allowed_groups.
+func TestHealth_FiltersByAppVisibility(t *testing.T) {
+	monitor := health.NewMonitor(30*time.Second, 5*time.Second)
+	monitor.SetApps([]health.AppConfig{
+		{Name: "public", URL: "http://localhost:1", Enabled: true},
+		{Name: "secret", URL: "http://localhost:2", Enabled: true},
+	})
+	cfg := &config.Config{Apps: []config.AppConfig{
+		{Name: "public"},
+		{Name: "secret", AllowedGroups: []string{"admins"}},
+	}}
+	h := NewHealthHandler(monitor, cfg, &sync.RWMutex{})
+
+	nonAdmin := func(method, path string) *http.Request {
+		req := httptest.NewRequest(method, path, nil)
+		return req.WithContext(auth.WithUserContext(req.Context(), &auth.User{Username: "bob", Role: auth.RoleUser}))
+	}
+
+	// GetAllHealth: non-admin sees only the unrestricted app.
+	w := httptest.NewRecorder()
+	h.GetAllHealth(w, nonAdmin(http.MethodGet, "/api/apps/health"))
+	var all []*health.AppHealth
+	if err := json.NewDecoder(w.Body).Decode(&all); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, ah := range all {
+		if ah.Name == "secret" {
+			t.Fatal("non-admin must not see the restricted app's health")
+		}
+	}
+
+	// GetAppHealth: the restricted app reads as 404, not an existence oracle.
+	w = httptest.NewRecorder()
+	h.GetAppHealth(w, nonAdmin(http.MethodGet, "/api/apps/secret/health"))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("restricted app health should 404 for a non-admin, got %d", w.Code)
+	}
+}
+
 func TestGetAppHealth(t *testing.T) {
 	t.Run("found", func(t *testing.T) {
 		handler := setupHealthTest(t)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/apps/sonarr/health", nil)
+		req := adminHealthReq(http.MethodGet, "/api/apps/sonarr/health")
 		w := httptest.NewRecorder()
 
 		handler.GetAppHealth(w, req)
@@ -84,7 +136,7 @@ func TestGetAppHealth(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		handler := setupHealthTest(t)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/apps/nonexistent/health", nil)
+		req := adminHealthReq(http.MethodGet, "/api/apps/nonexistent/health")
 		w := httptest.NewRecorder()
 
 		handler.GetAppHealth(w, req)
@@ -97,7 +149,7 @@ func TestGetAppHealth(t *testing.T) {
 	t.Run("empty name", func(t *testing.T) {
 		handler := setupHealthTest(t)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/apps//health", nil)
+		req := adminHealthReq(http.MethodGet, "/api/apps//health")
 		w := httptest.NewRecorder()
 
 		handler.GetAppHealth(w, req)
@@ -112,7 +164,7 @@ func TestCheckAppHealth(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		handler := setupHealthTest(t)
 
-		req := httptest.NewRequest(http.MethodPost, "/api/apps/nonexistent/health/check", nil)
+		req := adminHealthReq(http.MethodPost, "/api/apps/nonexistent/health/check")
 		w := httptest.NewRecorder()
 
 		handler.CheckAppHealth(w, req)
@@ -125,7 +177,7 @@ func TestCheckAppHealth(t *testing.T) {
 	t.Run("wrong method", func(t *testing.T) {
 		handler := setupHealthTest(t)
 
-		req := httptest.NewRequest(http.MethodGet, "/api/apps/sonarr/health/check", nil)
+		req := adminHealthReq(http.MethodGet, "/api/apps/sonarr/health/check")
 		w := httptest.NewRecorder()
 
 		handler.CheckAppHealth(w, req)
@@ -138,7 +190,7 @@ func TestCheckAppHealth(t *testing.T) {
 	t.Run("empty name", func(t *testing.T) {
 		handler := setupHealthTest(t)
 
-		req := httptest.NewRequest(http.MethodPost, "/api/apps//health/check", nil)
+		req := adminHealthReq(http.MethodPost, "/api/apps//health/check")
 		w := httptest.NewRecorder()
 
 		handler.CheckAppHealth(w, req)
@@ -160,9 +212,10 @@ func TestCheckAppHealth(t *testing.T) {
 			{Name: "testapp", URL: backend.URL, Enabled: true},
 		})
 
-		handler := NewHealthHandler(monitor)
+		cfg := &config.Config{Apps: []config.AppConfig{{Name: "testapp"}}}
+		handler := NewHealthHandler(monitor, cfg, &sync.RWMutex{})
 
-		req := httptest.NewRequest(http.MethodPost, "/api/apps/testapp/health/check", nil)
+		req := adminHealthReq(http.MethodPost, "/api/apps/testapp/health/check")
 		w := httptest.NewRecorder()
 
 		handler.CheckAppHealth(w, req)

--- a/internal/handlers/http_action_test.go
+++ b/internal/handlers/http_action_test.go
@@ -17,6 +17,44 @@ import (
 	"github.com/mescon/muximux/v3/internal/config"
 )
 
+// TestActionClient_DoesNotFollowRedirects: http_action targets are
+// admin-configured (a private-IP homelab webhook is legitimate, so the
+// initial request is not IP-filtered), but the redirect Location is
+// controlled by the target server -- an external target that 302s to
+// 169.254.169.254 or 127.0.0.1 would let it drive internal requests
+// server-side. The client must not follow redirects.
+func TestActionClient_DoesNotFollowRedirects(t *testing.T) {
+	internalHit := false
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		internalHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer internal.Close()
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	h := NewAPIHandler(&config.Config{}, "", &sync.RWMutex{})
+	req, err := http.NewRequest(http.MethodGet, redirector.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := h.actionClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("redirect must not be followed; want 302, got %d", resp.StatusCode)
+	}
+	if internalHit {
+		t.Error("actionClient followed the redirect to the internal target (SSRF)")
+	}
+}
+
 func newFireActionTest(t *testing.T, app *config.AppConfig, upstream http.HandlerFunc) *APIHandler {
 	t.Helper()
 	server := httptest.NewServer(upstream)

--- a/internal/handlers/icons.go
+++ b/internal/handlers/icons.go
@@ -427,11 +427,17 @@ func (h *IconHandler) UploadCustomIcon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Determine content type
-	contentType := header.Header.Get(headerContentType)
-	if contentType == "" || contentType == "application/octet-stream" {
-		// Detect from file content
-		contentType = http.DetectContentType(data)
+	// Determine content type from the bytes, not the client-declared
+	// multipart Content-Type. A client can label any payload
+	// image/svg+xml; if we trusted that, HTML/JS bytes would be stored as
+	// .svg and later served with Content-Type: image/svg+xml -- stored
+	// XSS on the dashboard origin. resolveIconContentType honours a type
+	// only when the bytes actually sniff to an allowed image (and an SVG
+	// claim only when the bytes look like SVG), returning "" otherwise.
+	contentType := resolveIconContentType(data, header.Header.Get(headerContentType))
+	if contentType == "" {
+		respondError(w, r, http.StatusBadRequest, "Unsupported file type", "source", "icons", "name", name)
+		return
 	}
 
 	// Save the icon

--- a/internal/handlers/icons_test.go
+++ b/internal/handlers/icons_test.go
@@ -304,6 +304,43 @@ func TestUploadCustomIcon(t *testing.T) {
 		}
 	})
 
+	// A client can set any Content-Type on a multipart part. If the upload
+	// handler trusts that header, an attacker uploads HTML/JS bytes while
+	// declaring image/svg+xml; the icon is stored as .svg and later served
+	// with Content-Type: image/svg+xml -- stored XSS on the dashboard
+	// origin. The handler must sniff the bytes and reject a payload that is
+	// not actually one of the allowed image types.
+	t.Run("rejects html masquerading as svg", func(t *testing.T) {
+		dir := t.TempDir()
+		handler, _ := NewIconHandler(nil, nil, dir)
+
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		h := make(textproto.MIMEHeader)
+		h["Content-Disposition"] = []string{`form-data; name="icon"; filename="evil.svg"`}
+		h["Content-Type"] = []string{"image/svg+xml"}
+		part, err := writer.CreatePart(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = part.Write([]byte(`<!DOCTYPE html><html><body><script>alert(document.domain)</script></body></html>`)); err != nil {
+			t.Fatal(err)
+		}
+		if err = writer.WriteField("name", "evil"); err != nil {
+			t.Fatal(err)
+		}
+		writer.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/api/icons/custom", &buf)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		w := httptest.NewRecorder()
+		handler.UploadCustomIcon(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400 for html-as-svg upload, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
 	t.Run("no file", func(t *testing.T) {
 		dir := t.TempDir()
 		handler, _ := NewIconHandler(nil, nil, dir)

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -1542,7 +1542,12 @@ func contentEncodingKind(ce string) encodingKind {
 	if ce == "" || strings.EqualFold(ce, "identity") {
 		return encodingIdentity
 	}
-	if strings.EqualFold(ce, "gzip") {
+	// "x-gzip" is a legacy alias for gzip with an identical wire format, so
+	// gzip.NewReader decodes it. Treat it as gzip so an old backend that
+	// still emits it gets its HTML decompressed and path-rewritten rather
+	// than forwarded un-rewritten. Note "x-compress"/"compress" (LZW) is a
+	// different format Go cannot decode, so it stays encodingOther.
+	if strings.EqualFold(ce, "gzip") || strings.EqualFold(ce, "x-gzip") {
 		return encodingGzip
 	}
 	return encodingOther

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -766,7 +766,58 @@ func buildSingleProxyRoute(app *config.AppConfig, timeout time.Duration, session
 // customHeaders are injected into every proxied request. sessionCookieName,
 // when non-empty, is removed from the outgoing Cookie header so the Muximux
 // session identifier is never leaked to the backend.
+// expandHeaderValue substitutes the supported identity variables in a
+// custom proxy-header value with the authenticated user's details, so an
+// operator can forward identity to a backend (e.g. `X-Forwarded-User:
+// ${user}`). Supported: ${user} (username), ${role}, ${email},
+// ${display_name}, ${groups} (comma-joined). An unauthenticated request
+// (auth.method=none) expands them to empty. Substituted values are
+// stripped of CR/LF/NUL so a crafted IdP claim can't inject a header or
+// smuggle a request. Unknown ${vars} are left untouched (a visible typo,
+// not a silent empty). The backend must only trust these headers from
+// Muximux.
+func expandHeaderValue(value string, user *auth.User) string {
+	if !strings.Contains(value, "${") {
+		return value
+	}
+	var username, role, email, displayName, groups string
+	if user != nil {
+		username = sanitizeHeaderValue(user.Username)
+		role = sanitizeHeaderValue(user.Role)
+		email = sanitizeHeaderValue(user.Email)
+		displayName = sanitizeHeaderValue(user.DisplayName)
+		groups = sanitizeHeaderValue(strings.Join(user.Groups, ","))
+	}
+	return strings.NewReplacer(
+		"${user}", username,
+		"${role}", role,
+		"${email}", email,
+		"${display_name}", displayName,
+		"${groups}", groups,
+	).Replace(value)
+}
+
+// sanitizeHeaderValue strips characters that would let a value break out
+// of its header (CR/LF) or terminate the field (NUL).
+func sanitizeHeaderValue(v string) string {
+	if !strings.ContainsAny(v, "\r\n\x00") {
+		return v
+	}
+	return strings.NewReplacer("\r", "", "\n", "", "\x00", "").Replace(v)
+}
+
 func buildDirector(proxyPrefix, targetPath string, targetURL *url.URL, customHeaders map[string]string, sessionCookieName string) func(*http.Request) {
+	// Precompute whether any custom-header value uses an identity
+	// template, so the common (static-header) path never touches the
+	// request context.
+	customHeadersTemplated := false
+	for _, v := range customHeaders {
+		if strings.Contains(v, "${") {
+			customHeadersTemplated = true
+			break
+		}
+	}
+
 	return func(req *http.Request) {
 		// Strip the /proxy/{slug} prefix from the request path
 		reqPath := strings.TrimPrefix(req.URL.Path, proxyPrefix)
@@ -786,9 +837,17 @@ func buildDirector(proxyPrefix, targetPath string, targetURL *url.URL, customHea
 		setProxyHeaders(req)
 		stripSessionCookie(req, sessionCookieName)
 
-		// Inject per-app custom headers (e.g., Authorization, X-Api-Key)
+		// Inject per-app custom headers (e.g., Authorization, X-Api-Key).
+		// Values may reference the authenticated user via ${user}/${role}/
+		// ${email}/${display_name}/${groups} to forward identity to the
+		// backend (proxy-auth pattern). The user is fetched once, only when
+		// a template is actually used.
+		var hdrUser *auth.User
+		if customHeadersTemplated {
+			hdrUser = auth.GetUserFromContext(req.Context())
+		}
 		for k, v := range customHeaders {
-			req.Header.Set(k, v)
+			req.Header.Set(k, expandHeaderValue(v, hdrUser))
 		}
 
 		req.Host = targetURL.Host

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -32,6 +32,12 @@ var (
 	sriHashesPattern    = regexp.MustCompile(`(\w+\.sriHashes)\s*=\s*\{[^}]+\}`)
 	srcsetPattern       = regexp.MustCompile(`(srcset\s*=\s*["'])([^"']+)(["'])`)
 	rootPathAttrPattern = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9-]*\s*=\s*["'])/([a-zA-Z0-9_][^"']*)`)
+	// rawTextBlockPattern matches an inline <script>/<style> block as
+	// three groups: opening tag, inner content, closing tag. The inner
+	// content is JS/CSS, not HTML, so HTML-attribute path rewriting must
+	// skip it (the opening tag -- e.g. `src="/app.js"` -- is still HTML
+	// and IS rewritten).
+	rawTextBlockPattern = regexp.MustCompile(`(?is)(<(?:script|style)\b[^>]*>)(.*?)(</(?:script|style)>)`)
 	rootPathUrlPattern  = regexp.MustCompile(`(url\s*\(\s*["']?)/([a-zA-Z0-9_-][^"')]*["']?\s*\))`)
 	baseHrefPattern     = regexp.MustCompile(`(<base[^>]*href\s*=\s*["'])([^"']*)(["'])`)
 	urlBaseEmptyPattern = regexp.MustCompile(`("?)(urlBase|basePath|baseUrl|baseHref)("?)\s*([:=])\s*(['"])(['"])`)
@@ -334,22 +340,52 @@ func (r *contentRewriter) rewriteRootPaths(result []byte) []byte {
 // rewriteRootPathAttrs rewrites attribute values starting with / but not /proxy/,
 // skipping srcset (handled separately).
 func (r *contentRewriter) rewriteRootPathAttrs(result []byte) []byte {
-	return rootPathAttrPattern.ReplaceAllFunc(result, func(match []byte) []byte {
-		if bytes.Contains(match, proxyPathPrefixB) {
-			return match
-		}
-		if bytes.HasPrefix(bytes.ToLower(match), []byte("srcset")) {
-			return match
-		}
-		quoteIdx := bytes.LastIndex(match, []byte(`"`))
-		if quoteIdx == -1 {
-			quoteIdx = bytes.LastIndex(match, []byte(`'`))
-		}
-		if quoteIdx == -1 {
-			return match
-		}
-		return spliceAt(match, quoteIdx+1, r.proxyPrefixB)
+	// The attribute pattern is an HTML construct; running it over inline
+	// <script>/<style> content false-matches JS/CSS assignments like
+	// `var apiBase="/api"` (the #371 class). Apply it only outside those
+	// blocks; the opening tag (e.g. a root-relative script src) is still
+	// rewritten.
+	return applyOutsideRawText(result, func(seg []byte) []byte {
+		return rootPathAttrPattern.ReplaceAllFunc(seg, func(match []byte) []byte {
+			if bytes.Contains(match, proxyPathPrefixB) {
+				return match
+			}
+			if bytes.HasPrefix(bytes.ToLower(match), []byte("srcset")) {
+				return match
+			}
+			quoteIdx := bytes.LastIndex(match, []byte(`"`))
+			if quoteIdx == -1 {
+				quoteIdx = bytes.LastIndex(match, []byte(`'`))
+			}
+			if quoteIdx == -1 {
+				return match
+			}
+			return spliceAt(match, quoteIdx+1, r.proxyPrefixB)
+		})
 	})
+}
+
+// applyOutsideRawText applies fn to the parts of an HTML document outside
+// inline <script>/<style> content. The block's opening tag is included in
+// the fn-processed region (so a root-relative script src is still
+// rewritten); only the raw JS/CSS body between the tags is left untouched.
+func applyOutsideRawText(content []byte, fn func([]byte) []byte) []byte {
+	locs := rawTextBlockPattern.FindAllSubmatchIndex(content, -1)
+	if len(locs) == 0 {
+		return fn(content)
+	}
+	out := make([]byte, 0, len(content))
+	last := 0
+	for _, loc := range locs {
+		// loc indices: [full0,full1, g1s,g1e, g2s,g2e, g3s,g3e].
+		// Process up to and including the opening tag (g1e); leave the
+		// inner content (g2) verbatim.
+		out = append(out, fn(content[last:loc[3]])...)
+		out = append(out, content[loc[3]:loc[5]]...)
+		last = loc[5]
+	}
+	out = append(out, fn(content[last:])...)
+	return out
 }
 
 // rewriteRootPathURLFunc rewrites CSS url() values with root-relative paths.
@@ -2136,7 +2172,39 @@ func (h *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	rc := http.NewResponseController(w)
 	_ = rc.SetWriteDeadline(time.Now().Add(h.timeout))
 
+	// Roll the READ deadline the same way for the request body, so a large
+	// upload proxied through here isn't severed by the server's absolute
+	// ReadTimeout while it keeps making progress (a stalled upload still
+	// times out after timeout of silence). The deadline is set lazily on
+	// the first body read and cleared on EOF, so it never lingers to sever
+	// a slow streaming RESPONSE that follows an empty or fully-read body.
+	// Non-proxy endpoints keep the server's absolute ReadTimeout.
+	if r.Body != nil && r.Body != http.NoBody {
+		r.Body = &deadlineResettingBody{ReadCloser: r.Body, rc: rc, timeout: h.timeout}
+	}
+
 	route.proxy.ServeHTTP(&deadlineResettingWriter{ResponseWriter: w, rc: rc, timeout: h.timeout}, r)
+}
+
+// deadlineResettingBody wraps the proxied request body and pushes the
+// connection read deadline forward by timeout on every Read, turning the
+// server's absolute ReadTimeout into a per-read idle deadline for uploads
+// (the read-side analog of deadlineResettingWriter).
+type deadlineResettingBody struct {
+	io.ReadCloser
+	rc      *http.ResponseController
+	timeout time.Duration
+}
+
+func (d *deadlineResettingBody) Read(p []byte) (int, error) {
+	_ = d.rc.SetReadDeadline(time.Now().Add(d.timeout))
+	n, err := d.ReadCloser.Read(p)
+	if err != nil {
+		// Body fully read (EOF) or errored: drop the read deadline so it
+		// can't sever the slow streaming RESPONSE that may follow.
+		_ = d.rc.SetReadDeadline(time.Time{})
+	}
+	return n, err
 }
 
 // deadlineResettingWriter wraps the proxy ResponseWriter and pushes the

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -1404,7 +1404,8 @@ func (r *contentRewriter) injectInterceptor(content []byte, docPath string) []by
 // maxRewriteSize is the maximum response body size (50 MB) that will be buffered
 // for URL rewriting. Text responses larger than this stream through unmodified to
 // avoid excessive memory use. In practice, HTML/CSS/JS are rarely this large.
-const maxRewriteSize = 50 * 1024 * 1024
+// A var (not const) only so tests can lower it without allocating 50 MB.
+var maxRewriteSize int64 = 50 * 1024 * 1024
 
 // maxPooledBodyBufSize caps which read buffers go back into the
 // pool. Without this, a single oversized response (e.g. a big
@@ -1440,11 +1441,19 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 		return nil
 	}
 
-	var reader io.Reader = resp.Body
+	orig := resp.Body
+	var reader io.Reader = orig
 	isGzipped := strings.Contains(resp.Header.Get(headerContentEncoding), "gzip")
 
+	// When gzipped, tee the compressed bytes as we decompress. If the
+	// decompressed body turns out to exceed the rewrite limit we forward
+	// the ORIGINAL compressed stream verbatim: the compressed bytes the
+	// gzip reader already consumed live in compressedSeen, the rest stays
+	// unread in orig, and the two concatenate to the exact original stream.
+	var compressedSeen *bytes.Buffer
 	if isGzipped {
-		gzReader, err := gzip.NewReader(resp.Body)
+		compressedSeen = &bytes.Buffer{}
+		gzReader, err := gzip.NewReader(io.TeeReader(orig, compressedSeen))
 		if err != nil {
 			// Surface decode failures so ReverseProxy's ErrorHandler can
 			// return a clean 502 rather than forwarding a partially-
@@ -1464,14 +1473,14 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 	// Read upstream body into a pooled buffer. The rewriter produces
 	// an independent []byte (every rewrite path allocates fresh), so
 	// once we've finished rewriting we can release the buffer back
-	// to the pool without aliasing risk.
+	// to the pool without aliasing risk. orig is NOT closed yet: on the
+	// over-limit path below we still need to forward its unread remainder.
 	buf := bodyReadBufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	if _, err := buf.ReadFrom(limited); err != nil {
 		bodyReadBufPool.Put(buf)
 		return fmt.Errorf("proxy: read body: %w", err)
 	}
-	resp.Body.Close()
 	body := buf.Bytes()
 
 	// releaseBuf returns the read buffer to the pool when safe.
@@ -1484,20 +1493,32 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 		}
 	}
 
-	// Safety net for chunked responses without Content-Length: if the body
-	// exceeds the rewrite limit, return it unmodified rather than rewriting.
+	// Over the rewrite limit (chunked/gzipped responses whose full size
+	// isn't known up front from Content-Length). Forward the WHOLE
+	// original stream unmodified rather than truncating it to the first
+	// maxRewriteSize bytes. The prefix already read is spliced back in
+	// front of orig's unread remainder; headers (Content-Encoding,
+	// Content-Length) are left untouched so the framing stays valid.
 	if int64(len(body)) > maxRewriteSize {
-		// body aliases the pooled buffer; copy out before releasing
-		// so the response keeps a stable backing array.
-		bodyCopy := make([]byte, len(body))
-		copy(bodyCopy, body)
+		var prefix []byte
+		if isGzipped {
+			prefix = make([]byte, compressedSeen.Len())
+			copy(prefix, compressedSeen.Bytes())
+		} else {
+			prefix = make([]byte, len(body))
+			copy(prefix, body)
+		}
 		releaseBuf()
-		resp.Body = io.NopCloser(bytes.NewReader(bodyCopy))
-		resp.ContentLength = int64(len(bodyCopy))
-		resp.Header.Set("Content-Length", strconv.Itoa(len(bodyCopy)))
-		resp.Header.Del(headerContentEncoding)
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{io.MultiReader(bytes.NewReader(prefix), orig), orig}
 		return nil
 	}
+
+	// Under the limit: the buffer holds the entire body, so the original
+	// upstream reader can be closed now.
+	orig.Close()
 
 	lowerContentType := strings.ToLower(contentType)
 	isHTML := strings.Contains(lowerContentType, "text/html")

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -1500,6 +1500,17 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 		return nil
 	}
 
+	// A non-gzip Content-Encoding (br, deflate, zstd, ...) can't be decoded
+	// here. Rewriting would run the regexes over compressed bytes (a no-op)
+	// and then strip the Content-Encoding header off a still-compressed
+	// body -- garbage to the browser. We only ask backends for `gzip,
+	// identity`, but one that ignores Accept-Encoding could still send
+	// another; forward it untouched rather than corrupt it.
+	if ce := strings.TrimSpace(resp.Header.Get(headerContentEncoding)); ce != "" &&
+		!strings.Contains(ce, "gzip") && !strings.EqualFold(ce, "identity") {
+		return nil
+	}
+
 	orig := resp.Body
 	var reader io.Reader = orig
 	isGzipped := strings.Contains(resp.Header.Get(headerContentEncoding), "gzip")

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -1525,6 +1525,29 @@ var bodyReadBufPool = sync.Pool{
 // response body for content types that need URL rewriting (HTML, CSS, JS, JSON, XML).
 // Binary content types and responses exceeding maxRewriteSize are streamed through
 // without buffering.
+type encodingKind int
+
+const (
+	encodingIdentity encodingKind = iota // no encoding / "identity": rewrite as plaintext
+	encodingGzip                         // a single gzip layer: decompress then rewrite
+	encodingOther                        // anything else, or layered: forward untouched
+)
+
+// contentEncodingKind classifies a Content-Encoding header for rewriting.
+// Comparison is case-insensitive and by the whole value, not a substring:
+// a layered/multi-value encoding like "gzip, br" is encodingOther because
+// it is not a single gzip layer we can safely decode.
+func contentEncodingKind(ce string) encodingKind {
+	ce = strings.TrimSpace(ce)
+	if ce == "" || strings.EqualFold(ce, "identity") {
+		return encodingIdentity
+	}
+	if strings.EqualFold(ce, "gzip") {
+		return encodingGzip
+	}
+	return encodingOther
+}
+
 func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 	contentType := resp.Header.Get(headerContentType)
 	if !shouldRewriteContent(contentType) {
@@ -1542,14 +1565,18 @@ func rewriteResponseBody(resp *http.Response, rewriter *contentRewriter) error {
 	// body -- garbage to the browser. We only ask backends for `gzip,
 	// identity`, but one that ignores Accept-Encoding could still send
 	// another; forward it untouched rather than corrupt it.
-	if ce := strings.TrimSpace(resp.Header.Get(headerContentEncoding)); ce != "" &&
-		!strings.Contains(ce, "gzip") && !strings.EqualFold(ce, "identity") {
+	//
+	// The check is by exact (case-insensitive) encoding, not a substring:
+	// a layered/multi-value encoding like "gzip, br" is NOT a single gzip
+	// layer and must be forwarded untouched, not fed to gzip.NewReader.
+	ceKind := contentEncodingKind(resp.Header.Get(headerContentEncoding))
+	if ceKind == encodingOther {
 		return nil
 	}
 
 	orig := resp.Body
 	var reader io.Reader = orig
-	isGzipped := strings.Contains(resp.Header.Get(headerContentEncoding), "gzip")
+	isGzipped := ceKind == encodingGzip
 
 	// When gzipped, tee the compressed bytes as we decompress. If the
 	// decompressed body turns out to exceed the rewrite limit we forward

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -3940,7 +3940,10 @@ func TestContentEncodingKind(t *testing.T) {
 		"gzip":       encodingGzip,
 		"GZIP":       encodingGzip,
 		" gzip ":     encodingGzip,
+		"x-gzip":     encodingGzip, // legacy alias, identical wire format
+		"X-Gzip":     encodingGzip,
 		"br":         encodingOther,
+		"x-compress": encodingOther, // LZW, not gzip -- must NOT be decoded as gzip
 		"gzip, br":   encodingOther, // layered -> not a single gzip layer
 		"br, gzip":   encodingOther,
 		"gzip, gzip": encodingOther,

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -3859,3 +3859,30 @@ func TestBuildDirector_ExpandsIdentityHeaders(t *testing.T) {
 		t.Errorf("static header must be unchanged: %q", got)
 	}
 }
+
+// TestRewriteResponseBody_NonGzipEncodingPassThrough: a response with a
+// non-gzip Content-Encoding (e.g. br) must be forwarded untouched -- body
+// AND the encoding header -- not have its header stripped off a still-
+// compressed body.
+func TestRewriteResponseBody_NonGzipEncodingPassThrough(t *testing.T) {
+	rewriter := newContentRewriter("/proxy/app", "", "")
+	body := "\x1b\x2f\x00brotli-compressed-bytes-here" // opaque compressed bytes
+	resp := &http.Response{
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	resp.Header.Set("Content-Type", "text/html")
+	resp.Header.Set("Content-Encoding", "br")
+
+	if err := rewriteResponseBody(resp, rewriter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Header.Get("Content-Encoding") != "br" {
+		t.Errorf("Content-Encoding must be preserved, got %q", resp.Header.Get("Content-Encoding"))
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("body must be forwarded byte-for-byte")
+	}
+}

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -3729,3 +3729,74 @@ func TestBuildUpgradeRequest_StripsCookieAndInjectsHeaders(t *testing.T) {
 		t.Errorf("expected request line + Host, got:\n%s", out)
 	}
 }
+
+// TestRewriteResponseBody_OverLimitForwardsFullStream: a chunked response
+// (unknown Content-Length) larger than the rewrite limit must be
+// forwarded in full, not truncated to the first maxRewriteSize bytes.
+func TestRewriteResponseBody_OverLimitForwardsFullStream(t *testing.T) {
+	old := maxRewriteSize
+	maxRewriteSize = 1024
+	defer func() { maxRewriteSize = old }()
+
+	rewriter := newContentRewriter("/proxy/app", "", "")
+	body := "<html>" + strings.Repeat("x", 4096) + `<a href="/foo">` + strings.Repeat("y", 4096) + "</html>"
+	if int64(len(body)) <= maxRewriteSize {
+		t.Fatal("test body must exceed the lowered limit")
+	}
+	resp := &http.Response{
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: -1, // chunked / unknown length
+	}
+	resp.Header.Set("Content-Type", "text/html")
+
+	if err := rewriteResponseBody(resp, rewriter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("over-limit body must be forwarded in full and unmodified: got %d bytes, want %d", len(got), len(body))
+	}
+}
+
+// TestRewriteResponseBody_OverLimitGzipForwardsCompressed: a gzipped
+// response whose DECOMPRESSED size exceeds the limit (but whose compressed
+// size is under it, so it isn't fast-path skipped) must forward the
+// original compressed stream verbatim, keeping Content-Encoding: gzip.
+func TestRewriteResponseBody_OverLimitGzipForwardsCompressed(t *testing.T) {
+	old := maxRewriteSize
+	maxRewriteSize = 1024
+	defer func() { maxRewriteSize = old }()
+
+	rewriter := newContentRewriter("/proxy/app", "", "")
+	plain := "<html>" + strings.Repeat("z", 8192) + "</html>" // decompresses > limit
+	var gzbuf bytes.Buffer
+	gw := gzip.NewWriter(&gzbuf)
+	if _, err := gw.Write([]byte(plain)); err != nil {
+		t.Fatal(err)
+	}
+	gw.Close()
+	compressed := gzbuf.Bytes()
+	if int64(len(compressed)) > maxRewriteSize {
+		t.Fatal("compressed body must be under the limit so it is not fast-path skipped")
+	}
+
+	resp := &http.Response{
+		Header:        make(http.Header),
+		Body:          io.NopCloser(bytes.NewReader(compressed)),
+		ContentLength: int64(len(compressed)),
+	}
+	resp.Header.Set("Content-Type", "text/html")
+	resp.Header.Set("Content-Encoding", "gzip")
+
+	if err := rewriteResponseBody(resp, rewriter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(got, compressed) {
+		t.Errorf("over-limit gzip must forward the original compressed stream: got %d bytes, want %d", len(got), len(compressed))
+	}
+	if resp.Header.Get("Content-Encoding") != "gzip" {
+		t.Errorf("Content-Encoding must remain gzip, got %q", resp.Header.Get("Content-Encoding"))
+	}
+}

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -3800,3 +3800,62 @@ func TestRewriteResponseBody_OverLimitGzipForwardsCompressed(t *testing.T) {
 		t.Errorf("Content-Encoding must remain gzip, got %q", resp.Header.Get("Content-Encoding"))
 	}
 }
+
+// TestExpandHeaderValue covers the #388 identity-forwarding templates.
+func TestExpandHeaderValue(t *testing.T) {
+	user := &auth.User{Username: "alice", Role: "admin", Email: "a@x.io", DisplayName: "Alice A", Groups: []string{"staff", "ops"}}
+	cases := []struct {
+		name, in string
+		user     *auth.User
+		want     string
+	}{
+		{"static value untouched", "Bearer secret-token", user, "Bearer secret-token"},
+		{"dollar without brace untouched", "pa$$word", user, "pa$$word"},
+		{"user", "${user}", user, "alice"},
+		{"role", "${role}", user, "admin"},
+		{"email", "${email}", user, "a@x.io"},
+		{"display_name", "${display_name}", user, "Alice A"},
+		{"groups joined", "${groups}", user, "staff,ops"},
+		{"embedded + multiple", "u=${user};r=${role}", user, "u=alice;r=admin"},
+		{"unknown var left literal", "${unknown}", user, "${unknown}"},
+		{"unauthenticated -> empty", "${user}", nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := expandHeaderValue(c.in, c.user); got != c.want {
+				t.Errorf("expandHeaderValue(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestExpandHeaderValue_SanitizesCRLF: a crafted username (e.g. from an
+// IdP claim) must not inject a header via CR/LF/NUL.
+func TestExpandHeaderValue_SanitizesCRLF(t *testing.T) {
+	user := &auth.User{Username: "alice\r\nX-Injected: evil", Role: "user\x00"}
+	if got := expandHeaderValue("${user}", user); strings.ContainsAny(got, "\r\n\x00") {
+		t.Errorf("expanded value must not contain CR/LF/NUL: %q", got)
+	}
+	if got := expandHeaderValue("${user}", user); got != "aliceX-Injected: evil" {
+		t.Errorf("unexpected sanitized value: %q", got)
+	}
+}
+
+// TestBuildDirector_ExpandsIdentityHeaders: the Director resolves ${user}
+// per request from the auth context and leaves static headers alone.
+func TestBuildDirector_ExpandsIdentityHeaders(t *testing.T) {
+	target, _ := url.Parse("http://backend:8080")
+	dir := buildDirector("/proxy/app", "", target,
+		map[string]string{"X-Forwarded-User": "${user}", "X-Static": "keep"}, "muximux_session")
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/app/foo", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ContextKeyUser, &auth.User{Username: "bob"}))
+	dir(req)
+
+	if got := req.Header.Get("X-Forwarded-User"); got != "bob" {
+		t.Errorf("templated header not expanded from context: %q", got)
+	}
+	if got := req.Header.Get("X-Static"); got != "keep" {
+		t.Errorf("static header must be unchanged: %q", got)
+	}
+}

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -3931,3 +3931,50 @@ func TestDeadlineResettingBody_Delegates(t *testing.T) {
 		t.Errorf("body must be delegated verbatim, got %q", got)
 	}
 }
+
+// TestContentEncodingKind classifies encodings for the rewrite guard.
+func TestContentEncodingKind(t *testing.T) {
+	cases := map[string]encodingKind{
+		"":           encodingIdentity,
+		"identity":   encodingIdentity,
+		"gzip":       encodingGzip,
+		"GZIP":       encodingGzip,
+		" gzip ":     encodingGzip,
+		"br":         encodingOther,
+		"gzip, br":   encodingOther, // layered -> not a single gzip layer
+		"br, gzip":   encodingOther,
+		"gzip, gzip": encodingOther,
+		"deflate":    encodingOther,
+	}
+	for in, want := range cases {
+		if got := contentEncodingKind(in); got != want {
+			t.Errorf("contentEncodingKind(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// TestRewriteResponseBody_LayeredEncodingPassThrough: a multi-value
+// Content-Encoding (gzip, br) must be forwarded untouched, not fed to the
+// gzip reader (which would 502 or, for br,gzip, corrupt the body).
+func TestRewriteResponseBody_LayeredEncodingPassThrough(t *testing.T) {
+	rewriter := newContentRewriter("/proxy/app", "", "")
+	body := "opaque-doubly-compressed-bytes"
+	resp := &http.Response{
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	resp.Header.Set("Content-Type", "text/html")
+	resp.Header.Set("Content-Encoding", "gzip, br")
+
+	if err := rewriteResponseBody(resp, rewriter); err != nil {
+		t.Fatalf("layered encoding must not error (502): %v", err)
+	}
+	if resp.Header.Get("Content-Encoding") != "gzip, br" {
+		t.Errorf("Content-Encoding must be preserved, got %q", resp.Header.Get("Content-Encoding"))
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != body {
+		t.Errorf("body must be forwarded byte-for-byte")
+	}
+}

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -3886,3 +3886,48 @@ func TestRewriteResponseBody_NonGzipEncodingPassThrough(t *testing.T) {
 		t.Errorf("body must be forwarded byte-for-byte")
 	}
 }
+
+// TestRewriteRootPathAttrs_SkipsInlineScript (#29): the HTML-attribute
+// path pattern must not rewrite ${...}-free root paths that appear inside
+// an inline <script> (they're JS assignments, not HTML attributes), but
+// must still rewrite real HTML attributes -- including a <script src>.
+func TestRewriteRootPathAttrs_SkipsInlineScript(t *testing.T) {
+	r := newContentRewriter("/proxy/app", "", "")
+	in := `<div data-x="/a"></div>` +
+		`<script src="/loader.js">var apiBase="/api/v1"; go("/dash");</script>` +
+		`<a href="/c">x</a>`
+	out := string(r.rewriteRootPathAttrs([]byte(in)))
+
+	// Inline JS assignments must be untouched.
+	if !strings.Contains(out, `var apiBase="/api/v1"`) {
+		t.Errorf("inline script JS must not be rewritten:\n%s", out)
+	}
+	if !strings.Contains(out, `go("/dash")`) {
+		t.Errorf("inline script call arg must not be rewritten:\n%s", out)
+	}
+	// Real HTML attributes (incl. the script's own src) must be rewritten.
+	for _, want := range []string{`data-x="/proxy/app/a"`, `src="/proxy/app/loader.js"`, `href="/proxy/app/c"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestDeadlineResettingBody_Delegates (#9): the rolling-deadline body
+// wrapper forwards reads to the underlying body (the SetReadDeadline call
+// is best-effort and ignored when unsupported).
+func TestDeadlineResettingBody_Delegates(t *testing.T) {
+	rc := http.NewResponseController(httptest.NewRecorder()) // no deadline support
+	b := &deadlineResettingBody{
+		ReadCloser: io.NopCloser(strings.NewReader("upload-bytes")),
+		rc:         rc,
+		timeout:    time.Second,
+	}
+	got, err := io.ReadAll(b)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "upload-bytes" {
+		t.Errorf("body must be delegated verbatim, got %q", got)
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -94,6 +94,38 @@ func TestInit_FileOutput(t *testing.T) {
 	}
 }
 
+// TestInfoAfterCloseIsDropped guards the shutdown-ordering invariant that
+// main() relies on: once Close() tears the logger down, a subsequent log
+// call is written to the closed file and does not reach it. If this ever
+// stopped being true, the ordering fix in main (log "Goodbye!" before
+// Close) would be unnecessary -- but as long as it holds, logging after
+// Close silently loses the line.
+func TestInfoAfterCloseIsDropped(t *testing.T) {
+	defaultLogger = nil
+
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "close.log")
+	if err := Init(Config{Level: LevelInfo, Format: "text", Output: logFile}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	Info("before-close-marker", "source", "test")
+	Close()
+	Info("after-close-marker", "source", "test")
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "before-close-marker") {
+		t.Error("expected the pre-close line to reach the file")
+	}
+	if strings.Contains(got, "after-close-marker") {
+		t.Error("a log call after Close() reached the file; main() must log its final line before Close()")
+	}
+}
+
 func TestInit_InvalidFilePath(t *testing.T) {
 	defaultLogger = nil
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -581,15 +581,20 @@ func writeGatewaySiteBlock(b *strings.Builder, s *GatewaySite, gatewayListen, in
 
 	b.WriteString("\t}\n")
 
-	// Frame-blocker stripping is implemented as response-header
-	// rewrites: drop X-Frame-Options entirely and rewrite (or inject)
-	// CSP frame-ancestors so Muximux's own origin can iframe this
-	// site. The {scheme}://{host} placeholders resolve at request
-	// time so Muximux deployments behind a reverse proxy still get
-	// the right Origin.
+	// Frame-blocker stripping. The operator opted in to embedding this
+	// gateway subdomain in Muximux's dashboard, which lives on a DIFFERENT
+	// origin (e.g. sonarr.example.com vs muximux.example.com). Remove both
+	// framing headers the backend might send. The previous code re-added
+	// `frame-ancestors 'self'`, but at a gateway site "self" is the site's
+	// own origin, so it blocked the cross-origin dashboard -- the opposite
+	// of the feature's intent (a Caddy `{host}` placeholder can't help
+	// either: it resolves to the gateway host, not the dashboard's). We
+	// can't reliably name the dashboard origin here, so strip the CSP
+	// rather than re-add a restrictive one; this is no less protective
+	// than the old behavior, which already discarded the backend's CSP.
 	if s.StripFrameBlockers {
 		b.WriteString("\theader -X-Frame-Options\n")
-		b.WriteString("\theader Content-Security-Policy \"frame-ancestors 'self'\"\n")
+		b.WriteString("\theader -Content-Security-Policy\n")
 	}
 
 	b.WriteString("}\n")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -595,7 +595,10 @@ func writeGatewaySiteBlock(b *strings.Builder, s *GatewaySite, gatewayListen, in
 	// no worse than the old code, which already replaced the backend CSP.
 	if s.StripFrameBlockers {
 		b.WriteString("\theader -X-Frame-Options\n")
-		if dashboardDomain != "" && !strings.ContainsAny(dashboardDomain, " \t\r\n\"'{}") {
+		// The blacklist includes backslash: inside a Caddyfile double-quoted
+		// token only \" is an escape, so a trailing backslash (example.com\)
+		// would escape the closing quote and corrupt the rest of the config.
+		if dashboardDomain != "" && !strings.ContainsAny(dashboardDomain, " \t\r\n\"'{}\\") {
 			fmt.Fprintf(b, "\theader Content-Security-Policy \"frame-ancestors 'self' https://%s\"\n", dashboardDomain)
 		} else {
 			b.WriteString("\theader -Content-Security-Policy\n")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -469,7 +469,7 @@ func (p *Proxy) buildCaddyfile() string {
 
 	// Emit each structured gateway site as its own Caddy site block.
 	for i := range p.config.GatewaySites {
-		writeGatewaySiteBlock(&b, &p.config.GatewaySites[i], p.config.GatewayListen, p.config.InternalAddr)
+		writeGatewaySiteBlock(&b, &p.config.GatewaySites[i], p.config.GatewayListen, p.config.InternalAddr, p.config.Domain)
 	}
 
 	return b.String()
@@ -483,7 +483,7 @@ func (p *Proxy) buildCaddyfile() string {
 // this site. Empty: legacy 80/443 with auto-HTTPS. Non-empty (e.g.
 // ":8443"): the site is served on that address as plain HTTP unless
 // TLS=custom (which keeps the operator-supplied cert).
-func writeGatewaySiteBlock(b *strings.Builder, s *GatewaySite, gatewayListen, internalAddr string) {
+func writeGatewaySiteBlock(b *strings.Builder, s *GatewaySite, gatewayListen, internalAddr, dashboardDomain string) {
 	b.WriteString("\n")
 
 	// Site selector. Three shapes:
@@ -583,18 +583,23 @@ func writeGatewaySiteBlock(b *strings.Builder, s *GatewaySite, gatewayListen, in
 
 	// Frame-blocker stripping. The operator opted in to embedding this
 	// gateway subdomain in Muximux's dashboard, which lives on a DIFFERENT
-	// origin (e.g. sonarr.example.com vs muximux.example.com). Remove both
-	// framing headers the backend might send. The previous code re-added
-	// `frame-ancestors 'self'`, but at a gateway site "self" is the site's
-	// own origin, so it blocked the cross-origin dashboard -- the opposite
-	// of the feature's intent (a Caddy `{host}` placeholder can't help
-	// either: it resolves to the gateway host, not the dashboard's). We
-	// can't reliably name the dashboard origin here, so strip the CSP
-	// rather than re-add a restrictive one; this is no less protective
-	// than the old behavior, which already discarded the backend's CSP.
+	// origin (e.g. sonarr.example.com vs muximux.example.com). The old
+	// code re-added `frame-ancestors 'self'`, but at a gateway site "self"
+	// is the site's own origin, so it blocked the cross-origin dashboard
+	// -- the opposite of the feature's intent. Emit a scoped policy that
+	// allows the site itself AND the dashboard origin, so the embed works
+	// while every other origin is still blocked (no clickjacking). When
+	// the dashboard domain isn't known (no server.tls.domain, e.g. behind
+	// an external proxy), fall back to stripping the backend's framing CSP
+	// -- for this opt-in, trusted-backend feature that's acceptable, and
+	// no worse than the old code, which already replaced the backend CSP.
 	if s.StripFrameBlockers {
 		b.WriteString("\theader -X-Frame-Options\n")
-		b.WriteString("\theader -Content-Security-Policy\n")
+		if dashboardDomain != "" && !strings.ContainsAny(dashboardDomain, " \t\r\n\"'{}") {
+			fmt.Fprintf(b, "\theader Content-Security-Policy \"frame-ancestors 'self' https://%s\"\n", dashboardDomain)
+		} else {
+			b.WriteString("\theader -Content-Security-Policy\n")
+		}
 	}
 
 	b.WriteString("}\n")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -344,29 +344,42 @@ func TestProxy_buildCaddyfile_GatewaySite_StreamingFlushInterval(t *testing.T) {
 }
 
 func TestProxy_buildCaddyfile_GatewaySite_StripFrameBlockers(t *testing.T) {
+	// With a dashboard domain configured, the CSP is scoped to allow the
+	// site itself AND the dashboard origin (embed works; other origins
+	// blocked -- no clickjacking).
 	p := New(&Config{
 		ListenAddr:   ":8080",
 		InternalAddr: "127.0.0.1:18080",
+		Domain:       "muximux.example.com",
 		GatewaySites: []GatewaySite{{
 			Domain:             "embedded.example.com",
 			BackendURL:         "http://app:8080",
 			StripFrameBlockers: true,
 		}},
 	})
-
 	cf := p.buildCaddyfile()
-
 	if !strings.Contains(cf, "header -X-Frame-Options") {
 		t.Error("expected X-Frame-Options strip directive")
 	}
-	if !strings.Contains(cf, "header -Content-Security-Policy") {
-		t.Error("expected the backend CSP to be stripped so the dashboard can embed the site")
+	if !strings.Contains(cf, "frame-ancestors 'self' https://muximux.example.com") {
+		t.Errorf("expected a scoped frame-ancestors allowing the dashboard origin:\n%s", cf)
 	}
-	// The old code re-added `frame-ancestors 'self'`, which (since a
-	// gateway site is a different origin than the dashboard) blocked the
-	// embed -- the opposite of the feature's intent. It must not reappear.
-	if strings.Contains(cf, "frame-ancestors") {
-		t.Errorf("must NOT re-add a restrictive frame-ancestors CSP:\n%s", cf)
+
+	// Without a dashboard domain (e.g. behind an external proxy), fall
+	// back to stripping the backend CSP so the embed still works.
+	p2 := New(&Config{
+		ListenAddr:   ":8080",
+		InternalAddr: "127.0.0.1:18080",
+		GatewaySites: []GatewaySite{{
+			Domain: "embedded.example.com", BackendURL: "http://app:8080", StripFrameBlockers: true,
+		}},
+	})
+	cf2 := p2.buildCaddyfile()
+	if !strings.Contains(cf2, "header -Content-Security-Policy") {
+		t.Errorf("with no dashboard domain, expected the backend CSP to be stripped:\n%s", cf2)
+	}
+	if strings.Contains(cf2, "frame-ancestors") {
+		t.Errorf("fallback must not emit a restrictive frame-ancestors:\n%s", cf2)
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -359,11 +359,14 @@ func TestProxy_buildCaddyfile_GatewaySite_StripFrameBlockers(t *testing.T) {
 	if !strings.Contains(cf, "header -X-Frame-Options") {
 		t.Error("expected X-Frame-Options strip directive")
 	}
-	if !strings.Contains(cf, "Content-Security-Policy") {
-		t.Error("expected CSP frame-ancestors directive")
+	if !strings.Contains(cf, "header -Content-Security-Policy") {
+		t.Error("expected the backend CSP to be stripped so the dashboard can embed the site")
 	}
-	if !strings.Contains(cf, "frame-ancestors 'self'") {
-		t.Error("expected frame-ancestors 'self' value")
+	// The old code re-added `frame-ancestors 'self'`, which (since a
+	// gateway site is a different origin than the dashboard) blocked the
+	// embed -- the opposite of the feature's intent. It must not reappear.
+	if strings.Contains(cf, "frame-ancestors") {
+		t.Errorf("must NOT re-add a restrictive frame-ancestors CSP:\n%s", cf)
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -381,6 +381,26 @@ func TestProxy_buildCaddyfile_GatewaySite_StripFrameBlockers(t *testing.T) {
 	if strings.Contains(cf2, "frame-ancestors") {
 		t.Errorf("fallback must not emit a restrictive frame-ancestors:\n%s", cf2)
 	}
+
+	// A dashboard domain containing a backslash must never be interpolated
+	// into the quoted Caddyfile CSP token: inside a double-quoted token only
+	// \" is an escape, so a trailing backslash would escape the closing
+	// quote and corrupt the config. Fall back to stripping instead.
+	p3 := New(&Config{
+		ListenAddr:   ":8080",
+		InternalAddr: "127.0.0.1:18080",
+		Domain:       "evil.example.com\\",
+		GatewaySites: []GatewaySite{{
+			Domain: "embedded.example.com", BackendURL: "http://app:8080", StripFrameBlockers: true,
+		}},
+	})
+	cf3 := p3.buildCaddyfile()
+	if strings.Contains(cf3, "frame-ancestors") {
+		t.Errorf("a backslash in the dashboard domain must not reach the CSP token:\n%s", cf3)
+	}
+	if !strings.Contains(cf3, "header -Content-Security-Policy") {
+		t.Errorf("expected fallback to stripping CSP for an unsafe dashboard domain:\n%s", cf3)
+	}
 }
 
 func TestProxy_buildCaddyfile_GatewaySite_ProxyHeaders(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -432,11 +432,20 @@ func New(cfg *config.Config, configPath string, dataDir string, version, commit,
 	}
 
 	s.httpServer = &http.Server{
-		Addr:         goListenAddr,
-		Handler:      handler,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:    goListenAddr,
+		Handler: handler,
+		// ReadTimeout is an absolute deadline over the whole request
+		// including the body. It bounds slow-body slowloris on normal
+		// (small, size-capped) endpoints. The proxy path overrides it with
+		// a ROLLING read deadline (see ServeHTTP) so a large upload that
+		// keeps making progress isn't severed at 15s while a stalled one
+		// still times out -- the read-side mirror of the write side's
+		// deadline-resetting writer. ReadHeaderTimeout bounds header
+		// slowloris independently.
+		ReadTimeout:       15 * time.Second,
+		ReadHeaderTimeout: 15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	return s, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1726,13 +1726,29 @@ func (s *Server) Start() error {
 			// websocket.DockerStatePayload) through the single shared
 			// converter so the field copy lives in exactly one place.
 			BroadcastDockerStateChanged: func(appName string, state discovery.DockerState) {
-				s.wsHub.BroadcastDockerStateChanged(appName, handlers.DockerStatePayloadFromState(&state))
+				s.wsHub.BroadcastDockerStateChanged(appName, handlers.DockerStatePayloadFromState(&state), s.appAccessRestricted(appName))
 			},
 		})
 		go s.discoveryPoller.Run(context.Background())
 	}
 
 	return s.httpServer.ListenAndServe()
+}
+
+// appAccessRestricted reports whether the named app has a per-app
+// visibility gate (min_role or allowed_groups). The poller's docker-state
+// broadcast uses it to route a restricted app's realtime update to admin
+// clients only, matching the GET /api/discovery/docker-state filter. An
+// app not found in config is treated as restricted (fail safe).
+func (s *Server) appAccessRestricted(name string) bool {
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
+	for i := range s.config.Apps {
+		if s.config.Apps[i].Name == name {
+			return s.config.Apps[i].MinRole != "" || len(s.config.Apps[i].AllowedGroups) > 0
+		}
+	}
+	return true
 }
 
 // GetHub returns the WebSocket hub for broadcasting events

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -754,11 +754,11 @@ func (s *Server) setupHealthRoutes(mux *http.ServeMux, cfg *config.Config, wsHub
 
 	// Broadcast health changes via WebSocket
 	s.healthMonitor.SetHealthChangeCallback(func(appName string, appHealth *health.AppHealth) {
-		wsHub.BroadcastAppHealthUpdate(appName, appHealth)
+		wsHub.BroadcastAppHealthUpdate(appName, appHealth, s.appAccessRestricted(appName))
 	})
 
 	// Health check routes
-	healthHandler := handlers.NewHealthHandler(s.healthMonitor)
+	healthHandler := handlers.NewHealthHandler(s.healthMonitor, cfg, &s.configMu)
 	mux.HandleFunc("/api/apps/health", healthHandler.GetAllHealth)
 	mux.HandleFunc("/api/apps/", func(w http.ResponseWriter, r *http.Request) {
 		// Route /api/apps/{name}/health and /api/apps/{name}/health/check

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2397,12 +2397,15 @@ func securityHeadersMiddleware(next http.Handler, inlineScriptHash string) http.
 // cross-origin attacks. Every /api/ request that mutates state
 // (POST / PUT / DELETE / PATCH) must carry either:
 //
-//   - a JSON-style Content-Type (or multipart for icon uploads, or
-//     application/x-yaml for the import path), OR
+//   - a non-simple Content-Type (application/json, or application/x-yaml
+//     for the import path), OR
 //   - the `X-Requested-With` header.
 //
 // Cross-origin pages cannot send either without a CORS preflight that
 // we never grant, so this is enough to defeat browser-form CSRF.
+// multipart/form-data is intentionally excluded: it is CORS-simple and
+// so sendable cross-origin without a preflight, so the multipart icon
+// upload relies on X-Requested-With, which the SPA always sends.
 //
 // The earlier shape only checked POST / PUT and trusted the
 // browser's "non-simple method" preflight rule for DELETE / PATCH.
@@ -2439,8 +2442,15 @@ func csrfMiddleware(next http.Handler) http.Handler {
 		// X-Requested-With header. Either alone defeats the
 		// cross-origin browser-form vector.
 		ct := r.Header.Get(headerContentType)
+		// NB: multipart/form-data is deliberately NOT in this set. It is a
+		// CORS-simple content type, so a cross-origin page can POST it with
+		// credentials and no preflight -- accepting it as a CSRF marker
+		// would leave the icon-upload endpoint open to browser-form CSRF.
+		// Uploads must instead carry X-Requested-With (the SPA sends it;
+		// cross-origin callers cannot without a preflight we never grant).
+		// application/json and application/x-yaml are both non-simple and
+		// therefore do force a preflight.
 		hasSafeContentType := strings.HasPrefix(ct, contentTypeJSON) ||
-			strings.HasPrefix(ct, "multipart/form-data") ||
 			strings.HasPrefix(ct, "application/x-yaml")
 		hasRequestedWith := r.Header.Get("X-Requested-With") != ""
 		// X-Requested-With is the consistent opt-in marker on

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,6 +123,10 @@ func New(cfg *config.Config, configPath string, dataDir string, version, commit,
 	authHandler := handlers.NewAuthHandler(sessionStore, userStore, cfg, configPath, authMiddleware, &s.configMu)
 	authHandler.SetBypassRules(defaultBypassRules)
 	authHandler.SetSetupChecker(func() bool { return s.needsSetup.Load() })
+	// Migrate a legacy bcrypt api_key_hash to sha256: on first successful
+	// use, so an existing install closes the bcrypt DoS window without a
+	// manual key rotation.
+	authMiddleware.SetOnAPIKeyUpgrade(authHandler.UpgradeAPIKeyHash)
 
 	// Set up OIDC provider if configured
 	if cfg.Auth.OIDC.Enabled {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -225,6 +225,12 @@ func New(cfg *config.Config, configPath string, dataDir string, version, commit,
 	// call.
 	s.rebuildProxyRoutes = func() {
 		reverseProxyHandler.RebuildRoutes(cfg.Apps)
+		// Keep the health monitor's app set in step with config changes
+		// (add/remove/edit an app, or a poller URL refresh). Without this
+		// it stayed frozen at its boot snapshot until restart: new apps
+		// went unchecked, deleted apps kept being probed, and URL edits
+		// were checked against the stale URL.
+		s.setHealthApps(cfg.Apps)
 	}
 	api.SetOnConfigSave(s.rebuildProxyRoutes)
 
@@ -731,17 +737,7 @@ func (s *Server) setupHealthRoutes(mux *http.ServeMux, cfg *config.Config, wsHub
 
 	// Configure apps for health monitoring.
 	// Health checks are opt-in: only apps with health_check: true are monitored.
-	healthApps := make([]health.AppConfig, 0, len(cfg.Apps))
-	for i := range cfg.Apps {
-		hcEnabled := cfg.Apps[i].HealthCheck != nil && *cfg.Apps[i].HealthCheck
-		healthApps = append(healthApps, health.AppConfig{
-			Name:      cfg.Apps[i].Name,
-			URL:       cfg.Apps[i].URL,
-			HealthURL: cfg.Apps[i].HealthURL,
-			Enabled:   cfg.Apps[i].Enabled && hcEnabled,
-		})
-	}
-	s.healthMonitor.SetApps(healthApps)
+	s.setHealthApps(cfg.Apps)
 
 	// Broadcast health changes via WebSocket
 	s.healthMonitor.SetHealthChangeCallback(func(appName string, appHealth *health.AppHealth) {
@@ -2072,6 +2068,34 @@ func computeDashboardURL(cfg *config.Config) string {
 }
 
 // parseDuration parses a duration string like "7d", "24h", "30m"
+// buildHealthApps projects the app list into the health monitor's view.
+// Health checks are opt-in: an app is monitored only when it is enabled
+// AND has health_check: true. Used at startup and re-applied on every
+// config save so added/removed/edited apps (and poller URL refreshes)
+// take effect without a restart.
+// setHealthApps refreshes the health monitor's view of the apps. Called
+// at startup and after every config save so the monitored set tracks
+// config changes without a restart. Safe when the monitor is nil.
+func (s *Server) setHealthApps(apps []config.AppConfig) {
+	if s.healthMonitor != nil {
+		s.healthMonitor.SetApps(buildHealthApps(apps))
+	}
+}
+
+func buildHealthApps(apps []config.AppConfig) []health.AppConfig {
+	out := make([]health.AppConfig, 0, len(apps))
+	for i := range apps {
+		hcEnabled := apps[i].HealthCheck != nil && *apps[i].HealthCheck
+		out = append(out, health.AppConfig{
+			Name:      apps[i].Name,
+			URL:       apps[i].URL,
+			HealthURL: apps[i].HealthURL,
+			Enabled:   apps[i].Enabled && hcEnabled,
+		})
+	}
+	return out
+}
+
 func parseDuration(s string, defaultVal time.Duration) time.Duration {
 	if s == "" {
 		return defaultVal

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3075,3 +3075,35 @@ func TestServerStop(t *testing.T) {
 		}
 	})
 }
+
+// TestServer_setHealthApps_TracksConfigChanges: the health monitor's app
+// set follows config changes (the config-saved callback calls this), so
+// added/removed/edited apps take effect without a restart. Regression
+// guard for the monitor being frozen at its boot snapshot.
+func TestServer_setHealthApps_TracksConfigChanges(t *testing.T) {
+	mon := health.NewMonitor(time.Minute, time.Second)
+	s := &Server{healthMonitor: mon}
+	yes := true
+
+	s.setHealthApps([]config.AppConfig{
+		{Name: "A", URL: "http://a", Enabled: true, HealthCheck: &yes},
+	})
+	if _, ok := mon.GetAllHealth()["A"]; !ok {
+		t.Fatal("app A should be registered after setHealthApps")
+	}
+
+	// Config changed: A removed, B added.
+	s.setHealthApps([]config.AppConfig{
+		{Name: "B", URL: "http://b", Enabled: true, HealthCheck: &yes},
+	})
+	all := mon.GetAllHealth()
+	if _, ok := all["A"]; ok {
+		t.Error("app A should drop out of the monitor after removal")
+	}
+	if _, ok := all["B"]; !ok {
+		t.Error("app B should be added to the monitor after config change")
+	}
+
+	// A nil monitor must be a safe no-op.
+	(&Server{}).setHealthApps([]config.AppConfig{{Name: "X"}})
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -443,7 +443,13 @@ func TestCSRFMiddleware(t *testing.T) {
 	}{
 		{"GET API passes through", "GET", "/api/config", "", "", http.StatusOK},
 		{"POST API with JSON passes", "POST", "/api/config", "application/json", "", http.StatusOK},
-		{"POST API with multipart passes", "POST", "/api/icons/custom", "multipart/form-data; boundary=abc", "", http.StatusOK},
+		// multipart/form-data is a CORS-simple content type: a cross-origin
+		// fetch can send it with credentials and NO preflight. It must NOT
+		// be a CSRF-safe marker on its own -- the upload has to carry
+		// X-Requested-With (which the SPA sends and cross-origin callers
+		// cannot set without a preflight we never grant).
+		{"POST API with multipart alone blocked", "POST", "/api/icons/custom", "multipart/form-data; boundary=abc", "", http.StatusForbidden},
+		{"POST API with multipart + XRW passes", "POST", "/api/icons/custom", "multipart/form-data; boundary=abc", "XMLHttpRequest", http.StatusOK},
 		{"POST API with x-yaml passes", "POST", "/api/config/import", "application/x-yaml", "", http.StatusOK},
 		{"POST API without content-type blocked", "POST", "/api/config", "", "", http.StatusForbidden},
 		{"POST API with text/plain blocked", "POST", "/api/config", "text/plain", "", http.StatusForbidden},

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1475,7 +1475,7 @@ func TestRoutes_DockerLifecycle_Registered(t *testing.T) {
 // handler onto a bare mux exactly as New() does, then proves GET reaches the
 // handler (200, not a routing 404) and a non-GET hits the method guard (405).
 func TestRoutes_DockerStateMap_Registered(t *testing.T) {
-	cfg := &config.Config{}
+	cfg := &config.Config{Apps: []config.AppConfig{{Name: "sonarr"}}}
 	cfg.Discovery.Docker.Enabled = true
 	svc := discovery.NewService(&cfg.Discovery.Docker)
 	svc.SetDockerStateForApp("sonarr", &discovery.DockerState{Status: "running", Image: "img"})
@@ -1483,7 +1483,12 @@ func TestRoutes_DockerStateMap_Registered(t *testing.T) {
 	dh := handlers.NewDiscoveryHandler(svc, cfg, "", &sync.RWMutex{}, nil)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/discovery/docker-state", dh.GetDockerStateMap)
+	// In production the global RequireAuth injects the user; mimic that here
+	// so the handler's per-app visibility filter has a user to check against.
+	mux.HandleFunc("/api/discovery/docker-state", func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(auth.WithUserContext(r.Context(), &auth.User{Username: "admin", Role: auth.RoleAdmin}))
+		dh.GetDockerStateMap(w, r)
+	})
 
 	ts := httptest.NewServer(mux)
 	defer ts.Close()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1108,7 +1108,9 @@ func TestRegisterAPIRoutes(t *testing.T) {
 			{Name: "Group1", Color: "#ff0000"},
 		},
 	}
-	api := handlers.NewAPIHandler(cfg, "", &sync.RWMutex{})
+	// Real temp config path so SaveConfig writes into t.TempDir() instead
+	// of failing a rename in the package dir (which leaked .config-*.yaml).
+	api := handlers.NewAPIHandler(cfg, filepath.Join(t.TempDir(), "config.yaml"), &sync.RWMutex{})
 
 	noopAdmin := adminGuard(func(next http.HandlerFunc) http.HandlerFunc {
 		return next
@@ -1410,7 +1412,9 @@ func TestRoutes_DockerLifecycle_Registered(t *testing.T) {
 			{Name: "sonarr", URL: "http://a:8080", Enabled: true},
 		},
 	}
-	api := handlers.NewAPIHandler(cfg, "", &sync.RWMutex{})
+	// Real temp config path so SaveConfig writes into t.TempDir() instead
+	// of failing a rename in the package dir (which leaked .config-*.yaml).
+	api := handlers.NewAPIHandler(cfg, filepath.Join(t.TempDir(), "config.yaml"), &sync.RWMutex{})
 
 	noopAdmin := adminGuard(func(next http.HandlerFunc) http.HandlerFunc {
 		return next

--- a/internal/websocket/client_test.go
+++ b/internal/websocket/client_test.go
@@ -290,7 +290,7 @@ func TestBroadcast_FilterByRole(t *testing.T) {
 	// send channel). Then assert the admin saw both in order and the user
 	// saw exactly the health update.
 	hub.BroadcastConfigUpdate(map[string]string{"title": "sensitive"})
-	hub.BroadcastAppHealthUpdate("sonarr", map[string]string{"status": "up"})
+	hub.BroadcastAppHealthUpdate("sonarr", map[string]string{"status": "up"}, false)
 	time.Sleep(200 * time.Millisecond)
 
 	readAll := func(conn *websocket.Conn) []string {

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -193,13 +193,17 @@ func (h *Hub) BroadcastHealthUpdate(health interface{}) {
 }
 
 // BroadcastAppHealthUpdate sends an app-specific health update event
-func (h *Hub) BroadcastAppHealthUpdate(appName string, health interface{}) {
+func (h *Hub) BroadcastAppHealthUpdate(appName string, health interface{}, restricted bool) {
 	h.Broadcast(Event{
 		Type: EventAppHealthChanged,
 		Payload: map[string]interface{}{
 			"app":    appName,
 			"health": health,
 		},
+		// A restricted app (min_role / allowed_groups) delivers its health
+		// update to admin clients only, matching the health GET filter, so a
+		// non-admin can't learn a hidden app's existence or status.
+		adminOnly: restricted,
 	})
 }
 

--- a/internal/websocket/hub.go
+++ b/internal/websocket/hub.go
@@ -234,19 +234,25 @@ type DockerStateChangedEvent struct {
 	State   DockerStatePayload `json:"state"`
 }
 
-// BroadcastDockerStateChanged fans a per-app state update out to every
-// connected client. Not adminOnly: state visibility is for everyone
-// authenticated, mirroring the existing HealthIndicator behaviour.
-// Mutations are gated by the handler-side role/group check, not by
-// event filtering. state is taken by pointer to avoid copying the
-// (relatively heavy) payload on every call.
-func (h *Hub) BroadcastDockerStateChanged(appName string, state *DockerStatePayload) {
+// BroadcastDockerStateChanged fans a per-app state update out to connected
+// clients. When restricted is true (the app has a min_role or allowed_groups
+// gate) the update is delivered only to admin clients, so a non-admin cannot
+// learn the container status, image, or uptime of an app hidden from them --
+// the realtime companion to the per-app filter on GET /api/discovery/
+// docker-state. Non-admins still receive that app's state via the (filtered)
+// GET endpoint on the next poll if they are allowed to see it.
+//
+// The client set does not carry each user's groups, so this is a coarse gate
+// (admin vs not) rather than a full per-user check; it fails safe (never
+// over-delivers). state is taken by pointer to avoid copying the payload.
+func (h *Hub) BroadcastDockerStateChanged(appName string, state *DockerStatePayload, restricted bool) {
 	h.Broadcast(Event{
 		Type: EventDockerStateChanged,
 		Payload: DockerStateChangedEvent{
 			AppName: appName,
 			State:   *state,
 		},
+		adminOnly: restricted,
 	})
 }
 

--- a/internal/websocket/hub_test.go
+++ b/internal/websocket/hub_test.go
@@ -410,7 +410,7 @@ func TestHub_BroadcastDockerStateChanged_DeliversToAllClients(t *testing.T) {
 		Status: "exited",
 		Health: "none",
 		Image:  "linuxserver/sonarr:latest",
-	})
+	}, false)
 
 	select {
 	case msg := <-userSend:
@@ -428,6 +428,40 @@ func TestHub_BroadcastDockerStateChanged_DeliversToAllClients(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatalf("admin client never received event")
+	}
+}
+
+// TestHub_BroadcastDockerStateChanged_RestrictedAppAdminOnly guards the
+// realtime companion to the docker-state visibility filter: a restricted
+// app's state update must reach admin clients only, never a non-admin.
+func TestHub_BroadcastDockerStateChanged_RestrictedAppAdminOnly(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer hub.Close()
+
+	userSend := make(chan []byte, 16)
+	hub.Register(&Client{send: userSend, isAdmin: false})
+	adminSend := make(chan []byte, 16)
+	hub.Register(&Client{send: adminSend, isAdmin: true})
+	time.Sleep(20 * time.Millisecond)
+
+	hub.BroadcastDockerStateChanged("secret", &DockerStatePayload{Status: "running", Image: "sec"}, true)
+
+	// Admin receives it.
+	select {
+	case msg := <-adminSend:
+		if !strings.Contains(string(msg), `"app_name":"secret"`) {
+			t.Fatalf("admin payload mismatch: %s", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("admin client never received restricted event")
+	}
+	// Non-admin must NOT receive it.
+	select {
+	case msg := <-userSend:
+		t.Fatalf("non-admin must not receive a restricted app's state: %s", msg)
+	case <-time.After(300 * time.Millisecond):
+		// correct: nothing delivered
 	}
 }
 

--- a/internal/websocket/hub_test.go
+++ b/internal/websocket/hub_test.go
@@ -200,7 +200,7 @@ func TestHub_BroadcastAppHealthUpdate(t *testing.T) {
 	hub.Register(client)
 	time.Sleep(50 * time.Millisecond)
 
-	hub.BroadcastAppHealthUpdate("myapp", map[string]string{"status": "healthy"})
+	hub.BroadcastAppHealthUpdate("myapp", map[string]string{"status": "healthy"}, false)
 	time.Sleep(50 * time.Millisecond)
 
 	select {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -376,7 +376,7 @@
   "appForm_helpSkipTls": "Enabled by default. Disable this only if the backend has a valid, trusted TLS certificate and you want strict verification.",
   "appForm_skipTlsDesc": "Disable for backends with valid certificates",
   "appForm_customHeaders": "Custom headers",
-  "appForm_customHeadersDesc": "Sent to the backend on every proxied request (e.g. Authorization, X-Api-Key). Use ${user}, ${role}, ${email}, ${display_name}, or ${groups} in a value to forward the signed-in user's identity.",
+  "appForm_customHeadersDesc": "Sent to the backend on every proxied request (e.g. Authorization, X-Api-Key). Use $\\{user\\}, $\\{role\\}, $\\{email\\}, $\\{display_name\\}, or $\\{groups\\} in a value to forward the signed-in user's identity.",
   "appForm_headerName": "Header name",
   "appForm_headerValue": "Value",
   "appForm_removeHeader": "Remove header",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -376,7 +376,7 @@
   "appForm_helpSkipTls": "Enabled by default. Disable this only if the backend has a valid, trusted TLS certificate and you want strict verification.",
   "appForm_skipTlsDesc": "Disable for backends with valid certificates",
   "appForm_customHeaders": "Custom headers",
-  "appForm_customHeadersDesc": "Sent to the backend on every proxied request (e.g. Authorization, X-Api-Key)",
+  "appForm_customHeadersDesc": "Sent to the backend on every proxied request (e.g. Authorization, X-Api-Key). Use ${user}, ${role}, ${email}, ${display_name}, or ${groups} in a value to forward the signed-in user's identity.",
   "appForm_headerName": "Header name",
   "appForm_headerValue": "Value",
   "appForm_removeHeader": "Remove header",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "muximux3-web",
       "version": "3.0.0",
       "dependencies": {
+        "dompurify": "^3.4.11",
         "marked": "^18.0.5",
         "svelte-dnd-action": "^0.9.70",
         "svelte-sonner": "^1.1.1",
@@ -2366,6 +2367,15 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.6",

--- a/web/package.json
+++ b/web/package.json
@@ -42,6 +42,7 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
+    "dompurify": "^3.4.11",
     "marked": "^18.0.5",
     "svelte-dnd-action": "^0.9.70",
     "svelte-sonner": "^1.1.1",

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -14,7 +14,7 @@
   import { connect as connectWs, disconnect as disconnectWs, on as onWsEvent, connectionState } from './lib/websocketStore';
   import { initLogStore } from './lib/logStore';
   import { get } from 'svelte/store';
-  import { checkAuthStatus, isAuthenticated, isAdmin, login, setupRequired } from './lib/authStore';
+  import { checkAuthStatus, isAuthenticated, isAdmin, setupRequired } from './lib/authStore';
   import { resetOnboarding } from './lib/onboardingStore';
   import { initTheme, setTheme, syncFromConfig, loadCustomThemesFromServer } from './lib/themeStore';
   import { isFullscreen, toggleFullscreen, exitFullscreen } from './lib/fullscreenStore';
@@ -316,19 +316,10 @@
       return;
     }
 
-    // Auto-login after auth method transition (credentials stored by Settings)
-    const autoLogin = sessionStorage.getItem('muximux_auto_login');
-    if (autoLogin) {
-      sessionStorage.removeItem('muximux_auto_login');
-      try {
-        const { u, p } = JSON.parse(autoLogin);
-        if (u && p) {
-          await login(u, p, true);
-        }
-      } catch {
-        // Fall through — user will see the login form
-      }
-    }
+    // Note: the auth-method transition (enabling built-in auth from Settings)
+    // now logs in before reloading, so there is no stored-credential
+    // auto-login step here anymore -- the session cookie already carries the
+    // authenticated session across the reload.
 
     // Try to load config (will 401 if auth required and not logged in)
     try {

--- a/web/src/components/AppForm.svelte
+++ b/web/src/components/AppForm.svelte
@@ -529,7 +529,8 @@
           value={app.shortcut ?? ''}
           onchange={(e) => {
             const val = (e.target as HTMLSelectElement).value;
-            app.shortcut = val ? parseInt(val) : undefined;
+            const n = val ? parseInt(val, 10) : NaN;
+            app.shortcut = Number.isFinite(n) ? n : undefined;
           }}
           class="px-2 py-1 text-sm bg-bg-elevated border border-border-subtle rounded text-text-primary focus:ring-brand-500 focus:border-brand-500"
         >

--- a/web/src/components/AppIcon.svelte
+++ b/web/src/components/AppIcon.svelte
@@ -2,6 +2,7 @@
   import type { AppIcon as AppIconType } from '$lib/types';
   import { getBase } from '$lib/api';
   import { debug } from '$lib/debug';
+  import { safeColor } from '$lib/safeColor';
 
   let { icon, name, color = '#374151', size = 'md', showBackground = true, forceBackground = false, scale }: {
     icon: AppIconType;
@@ -53,15 +54,18 @@
   let fallbackLetter = $derived(name.charAt(0).toUpperCase());
   // When showBackground is enabled, use the icon's explicit background if set,
   // otherwise darken the app color to create contrast.
+  // Colours can come from Docker labels / imports, so validate every one
+  // before it reaches an inline style (see safeColor).
+  let safeBg = $derived(safeColor(icon?.background));
   let bgColor = $derived(
     (showBackground || forceBackground)
-      ? (icon?.background && icon.background !== 'transparent'
-          ? icon.background
-          : `color-mix(in srgb, ${color || '#374151'} 50%, black)`)
+      ? (safeBg && safeBg !== 'transparent'
+          ? safeBg
+          : `color-mix(in srgb, ${safeColor(color, '#374151')} 50%, black)`)
       : 'transparent'
   );
   // Icon tint color for Lucide (CSS mask); falls back to theme text color
-  let tintColor = $derived(icon?.color || '');
+  let tintColor = $derived(safeColor(icon?.color));
 
   let imageError = $state(false);
 

--- a/web/src/components/ConfirmDockerActionModal.svelte
+++ b/web/src/components/ConfirmDockerActionModal.svelte
@@ -2,11 +2,15 @@
   import { onMount } from 'svelte';
   import * as m from '$lib/paraglide/messages.js';
 
-  let { appName, action, image, uptimeOrExit, onconfirm, oncancel }: {
+  let { appName, action, image, uptimeOrExit, loading = false, onconfirm, oncancel }: {
     appName: string;
     action: 'stop' | 'restart';
     image: string;
     uptimeOrExit: string;
+    // While an action is in flight the modal stays open in a disabled,
+    // non-dismissable state so the operator sees progress and cannot
+    // re-fire or cancel a running start/stop/restart.
+    loading?: boolean;
     onconfirm?: () => void;
     oncancel?: () => void;
   } = $props();
@@ -25,6 +29,7 @@
   // the dialog, and torn down on unmount.
   onMount(() => {
     const handler = (e: KeyboardEvent) => {
+      if (loading) return; // ignore keys while an action is running
       if (e.key === 'Escape') {
         e.preventDefault();
         oncancel?.();
@@ -44,6 +49,7 @@
   data-testid="docker-confirm-modal-backdrop"
   role="presentation"
   onclick={(e) => {
+    if (loading) return; // don't dismiss while an action is running
     if (e.target === e.currentTarget) oncancel?.();
   }}
 >
@@ -52,12 +58,16 @@
     role="dialog"
     aria-modal="true"
     aria-labelledby="docker-confirm-heading"
+    aria-busy={loading}
   >
     <h2 id="docker-confirm-heading" class="modal-heading">{heading}</h2>
     <p class="modal-body">{m.docker_modal_body({ image, uptimeOrExit })}</p>
     <div class="modal-actions">
-      <button type="button" class="btn" onclick={() => oncancel?.()}>{m.common_cancel()}</button>
-      <button type="button" class="btn btn-primary" autofocus onclick={() => onconfirm?.()}>
+      <button type="button" class="btn" disabled={loading} onclick={() => oncancel?.()}>{m.common_cancel()}</button>
+      <button type="button" class="btn btn-primary" autofocus disabled={loading} onclick={() => onconfirm?.()}>
+        {#if loading}
+          <span class="inline-block w-4 h-4 me-2 border-2 border-white/30 border-t-white rounded-full animate-spin align-[-2px]"></span>
+        {/if}
         {m.common_confirm()}
       </button>
     </div>

--- a/web/src/components/ConfirmDockerActionModal.test.ts
+++ b/web/src/components/ConfirmDockerActionModal.test.ts
@@ -61,4 +61,25 @@ describe('ConfirmDockerActionModal', () => {
     await fireEvent.click(backdrop);
     expect(oncancel).toHaveBeenCalledOnce();
   });
+
+  // #27: while the confirmed action runs the modal stays open but is
+  // disabled/non-dismissable, so it cannot be re-fired or cancelled.
+  it('disables both buttons and marks the dialog busy while loading', () => {
+    const { getByText, container } = render(ConfirmDockerActionModal, {
+      props: { appName: 'sonarr', action: 'restart', image: 'x', uptimeOrExit: '', loading: true },
+    });
+    expect((getByText('Confirm').closest('button') as HTMLButtonElement).disabled).toBe(true);
+    expect((getByText('Cancel').closest('button') as HTMLButtonElement).disabled).toBe(true);
+    expect(container.querySelector('[role="dialog"]')?.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('ignores Escape and backdrop clicks while loading', async () => {
+    const oncancel = vi.fn();
+    const { container } = render(ConfirmDockerActionModal, {
+      props: { appName: 'sonarr', action: 'stop', image: 'x', uptimeOrExit: '', loading: true, oncancel },
+    });
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    await fireEvent.click(container.querySelector('.modal-backdrop') as HTMLElement);
+    expect(oncancel).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/components/Navigation.svelte
+++ b/web/src/components/Navigation.svelte
@@ -378,7 +378,10 @@
     // Restore sidebar width
     const storedWidth = localStorage.getItem('muximux_sidebar_width');
     if (storedWidth) {
-      sidebarWidth = parseInt(storedWidth, 10);
+      // Guard against corrupted storage: a non-numeric value would make
+      // parseInt return NaN and collapse the sidebar layout.
+      const w = parseInt(storedWidth, 10);
+      if (Number.isFinite(w) && w > 0) sidebarWidth = w;
     }
 
     // Set up responsive listeners

--- a/web/src/components/OnboardingWizard.svelte
+++ b/web/src/components/OnboardingWizard.svelte
@@ -878,7 +878,7 @@
   }
 </script>
 
-<div class="fixed inset-0 z-50 bg-bg-base overflow-hidden flex flex-col" onkeydown={handleGlobalKeydown} role="dialog" aria-label="Setup wizard" tabindex="0">
+<div class="fixed inset-0 z-50 bg-bg-base overflow-hidden flex flex-col" onkeydown={handleGlobalKeydown} role="dialog" aria-modal="true" aria-label="Setup wizard" tabindex="0">
   <!-- Top bar nav preview — rendered as wizard root flex child so it sits above the stepper -->
   {#if ($currentStep === 'navigation' || $currentStep === 'theme') && $selectedNavigation === 'top'}
     <div class="flex-shrink-0" style="z-index: 20;">

--- a/web/src/components/Settings.svelte
+++ b/web/src/components/Settings.svelte
@@ -4,6 +4,7 @@
   import { type App, type Config, type Group, makeApp, makeGroup, stampAppId, stampGroupId } from '$lib/types';
   import IconBrowser from './IconBrowser.svelte';
   import AppForm from './AppForm.svelte';
+  import { focusTrap } from '$lib/focusTrap';
   import AppIcon from './AppIcon.svelte';
   import KeybindingsEditor from './KeybindingsEditor.svelte';
   import AboutTab from './settings/AboutTab.svelte';
@@ -661,6 +662,11 @@
   >
     <div
       class="bg-bg-surface rounded-xl shadow-2xl w-full border border-border {addAppStep === 'choose' ? 'max-w-2xl' : 'max-w-lg'}"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-app-title"
+      tabindex="-1"
+      use:focusTrap
       in:fly={{ y: 10, duration: 150 }}
       out:fade={{ duration: 75 }}
     >
@@ -677,7 +683,7 @@
               </svg>
             </button>
           {/if}
-          <h3 class="text-lg font-semibold text-text-primary">{addAppStep === 'choose' ? m.settings_addApplication() : m.settings_configureApp({ appName: newApp.name || m.settings_appFallbackName() })}</h3>
+          <h3 id="add-app-title" class="text-lg font-semibold text-text-primary">{addAppStep === 'choose' ? m.settings_addApplication() : m.settings_configureApp({ appName: newApp.name || m.settings_appFallbackName() })}</h3>
         </div>
         <button
           class="btn btn-ghost btn-icon"
@@ -897,10 +903,15 @@
   >
     <div
       class="bg-bg-surface rounded-xl shadow-2xl w-full max-w-lg border border-border"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-app-title"
+      tabindex="-1"
+      use:focusTrap
       in:fly={{ y: 10, duration: 150 }}
     >
       <div class="flex items-center justify-between p-4 border-b border-border">
-        <h3 class="text-lg font-semibold text-text-primary">{m.settings_editApp({ appName: editingApp.name })}</h3>
+        <h3 id="edit-app-title" class="text-lg font-semibold text-text-primary">{m.settings_editApp({ appName: editingApp.name })}</h3>
         <button
           class="btn btn-ghost btn-icon"
           onclick={cancelEditApp}

--- a/web/src/components/Settings.test.ts
+++ b/web/src/components/Settings.test.ts
@@ -635,6 +635,23 @@ describe('Settings', () => {
       });
     });
 
+    // #26: the modal must be an accessible, labelled dialog and move focus
+    // into itself when opened.
+    it('exposes the Add App modal as a labelled dialog and moves focus in', async () => {
+      renderSettings({ initialTab: 'apps' });
+      await fireEvent.click(screen.getByTestId('trigger-add-app'));
+
+      const dialog = await screen.findByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      // aria-labelledby points at the heading, so the accessible name is set.
+      expect(dialog).toHaveAccessibleName('Add Application');
+      // focusTrap moved focus into the dialog rather than leaving it on the
+      // body / the trigger button outside.
+      await waitFor(() => {
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+    });
+
     it('shows search input and popular apps in choose step', async () => {
       renderSettings({ initialTab: 'apps' });
       await fireEvent.click(screen.getByTestId('trigger-add-app'));

--- a/web/src/components/Splash.svelte
+++ b/web/src/components/Splash.svelte
@@ -31,6 +31,9 @@
 
   // Pending stop/restart awaiting confirmation in the modal.
   let pendingAction = $state<{ app: App; action: 'stop' | 'restart' } | null>(null);
+  // True while the confirmed docker action is running, so the confirm modal
+  // stays open in a disabled/spinner state until it resolves.
+  let pendingActionRunning = $state(false);
 
   // Lifecycle actions that make sense for the current container state.
   // running -> stop/restart; stopped -> start; transitional/missing ->
@@ -420,12 +423,22 @@
     action={pendingAction.action}
     image={ds?.image ?? ''}
     uptimeOrExit={ds?.status === 'running' ? 'running' : `exit ${ds?.exit_code ?? 0}`}
+    loading={pendingActionRunning}
     onconfirm={async () => {
+      if (pendingActionRunning) return;
       const a = pendingAction!;
-      pendingAction = null;
-      await runAction(a.app, a.action);
+      // Keep the modal open (disabled) until the action resolves, then
+      // close. Closing before the await would drop all in-flight feedback
+      // and let the operator re-fire a long restart.
+      pendingActionRunning = true;
+      try {
+        await runAction(a.app, a.action);
+      } finally {
+        pendingActionRunning = false;
+        pendingAction = null;
+      }
     }}
-    oncancel={() => pendingAction = null}
+    oncancel={() => { if (!pendingActionRunning) pendingAction = null; }}
   />
 {/if}
 

--- a/web/src/components/Splash.svelte
+++ b/web/src/components/Splash.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import type { App, Config, DockerState } from '$lib/types';
+  import { safeColor } from '$lib/safeColor';
   import AppIcon from './AppIcon.svelte';
   import HealthIndicator from './HealthIndicator.svelte';
   import MuximuxLogo from './MuximuxLogo.svelte';
@@ -289,7 +290,7 @@
                     <!-- Glow effect -->
                     <div
                       class="absolute inset-0 rounded-full opacity-0 group-hover:opacity-40 transition-opacity blur-xl"
-                      style="background: {app.color || 'var(--accent-primary)'};"
+                      style="background: {safeColor(app.color, 'var(--accent-primary)')};"
                     ></div>
                     <div class="relative app-icon-wrapper">
                       <AppIcon icon={app.icon} name={app.name} color={app.color} size="xl" />
@@ -308,7 +309,7 @@
                   <!-- Color accent bar at bottom -->
                   <div
                     class="app-card-accent"
-                    style="background: {app.color || 'var(--accent-primary)'};"
+                    style="background: {safeColor(app.color, 'var(--accent-primary)')};"
                   ></div>
                 </button>
 

--- a/web/src/components/settings/AboutTab.svelte
+++ b/web/src/components/settings/AboutTab.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import type { SystemInfo, UpdateInfo } from '$lib/types';
   import { fetchSystemInfo, checkForUpdates } from '$lib/api';
+  import { renderChangelog } from '$lib/changelog';
   import * as m from '$lib/paraglide/messages.js';
 
   let systemInfo = $state<SystemInfo | null>(null);
@@ -28,13 +29,13 @@
       updateInfo = updInfo;
       if (updInfo?.changelog) {
         changelogExpanded = true;
-        // Pull marked off the main bundle. Failure here is silent on
-        // purpose: a missing parser just leaves parsedChangelog
-        // empty, which the template already handles via a
-        // truthy-check around the {@html ...} block.
+        // Parse + sanitize off the main bundle. The changelog is remote
+        // (update-check) content rendered via {@html}, so it must be
+        // sanitized before it hits the DOM (see renderChangelog). Failure
+        // here is silent on purpose: an empty parsedChangelog is handled
+        // by the truthy-check around the {@html ...} block.
         try {
-          const { marked } = await import('marked');
-          parsedChangelog = String(marked.parse(updInfo.changelog));
+          parsedChangelog = await renderChangelog(updInfo.changelog);
         } catch {
           parsedChangelog = '';
         }

--- a/web/src/components/settings/DiscoverModal.svelte
+++ b/web/src/components/settings/DiscoverModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { focusTrap } from '$lib/focusTrap';
   import type { App, DiscoverySuggestion, DiscoveryImportItem, DiscoveryImportResult, GatewaySite, AppIcon as AppIconType } from '$lib/types';
   import { scanDockerContainers, importDockerSuggestions } from '$lib/api';
   import AppIcon from '../AppIcon.svelte';
@@ -337,11 +337,11 @@
 {/snippet}
 
 {#if open}
-  <div class="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4" role="dialog" aria-modal="true">
+  <div class="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-labelledby="discover-modal-title" tabindex="-1" use:focusTrap={{ onEscape: onclose }}>
     <div class="bg-bg-base border border-border rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
       <header class="px-5 py-4 border-b border-border flex items-center justify-between">
         <div>
-          <h2 class="text-lg font-semibold text-text-primary">Discover from Docker</h2>
+          <h2 id="discover-modal-title" class="text-lg font-semibold text-text-primary">Discover from Docker</h2>
           <p class="text-xs text-text-muted mt-0.5">
             {#if mode === 'apps'}
               Each container becomes an app in your menu by default. Toggle "Gateway" to also expose it on a subdomain.

--- a/web/src/components/settings/DiscoveryRelinkModal.svelte
+++ b/web/src/components/settings/DiscoveryRelinkModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { DiscoveryRelinkProbeResult, DiscoveryRelinkCandidate } from '$lib/types';
   import { probeDockerRelink, confirmDockerRelink, detachDockerTracked } from '$lib/api';
+  import { focusTrap } from '$lib/focusTrap';
 
   let { trackingKey, onClose } = $props<{ trackingKey: string; onClose: () => void }>();
 
@@ -63,6 +64,8 @@
   role="dialog"
   aria-modal="true"
   aria-labelledby="relink-modal-title"
+  tabindex="-1"
+  use:focusTrap={{ onEscape: onClose }}
   data-testid="relink-modal"
 >
   <div class="bg-bg-base border border-border rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto">

--- a/web/src/components/settings/DiscoveryRelinkModal.test.ts
+++ b/web/src/components/settings/DiscoveryRelinkModal.test.ts
@@ -37,6 +37,19 @@ describe('DiscoveryRelinkModal probe outcomes', () => {
     expect(screen.getByTestId('relink-confirm-btn')).toBeInTheDocument();
   });
 
+  it('closes on Escape (focus-trap a11y)', async () => {
+    mockApi.probeDockerRelink.mockResolvedValue({
+      found: true,
+      container: { key: 'name:sonarr', name: 'sonarr', image: 'linuxserver/sonarr' },
+    } satisfies DiscoveryRelinkProbeResult);
+    const onClose = vi.fn();
+    render(DiscoveryRelinkModal, { trackingKey: 'name:sonarr-old', onClose });
+
+    const dialog = await screen.findByTestId('relink-modal');
+    await fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
   it('renders the candidate picker when no match is found', async () => {
     mockApi.probeDockerRelink.mockResolvedValue({
       found: false,

--- a/web/src/components/settings/SecurityTab.svelte
+++ b/web/src/components/settings/SecurityTab.svelte
@@ -3,7 +3,7 @@
   import { fly } from 'svelte/transition';
   import type { Config, UserInfo, ChangeAuthMethodRequest } from '$lib/types';
   import { listUsers, createUser, updateUser, deleteUserAccount, changeAuthMethod, getAPIKeyStatus, generateAPIKey, deleteAPIKey } from '$lib/api';
-  import { changePassword, isAdmin, currentUser } from '$lib/authStore';
+  import { changePassword, login, isAdmin, currentUser } from '$lib/authStore';
   import { forwardAuthPresets, applyPreset, detectPreset, buildForwardAuthRequest, type PresetName } from '$lib/forwardAuthPresets';
   import * as m from '$lib/paraglide/messages.js';
 
@@ -462,9 +462,19 @@
                         } finally {
                           methodLoading = false;
                         }
-                        // Auth middleware is now "builtin" — store credentials for auto-login after reload
+                        // Auth middleware is now "builtin", so this page has no
+                        // valid session. Log in NOW to set the session cookie, then
+                        // reload into an authenticated page. Doing the login here
+                        // (rather than stashing the plaintext password in
+                        // sessionStorage for an after-reload auto-login) keeps the
+                        // password out of web storage entirely.
                         sessionStorage.setItem('muximux_return_to', 'security');
-                        sessionStorage.setItem('muximux_auto_login', JSON.stringify({ u: savedUser, p: savedPass }));
+                        try {
+                          await login(savedUser, savedPass, true);
+                        } catch {
+                          // Even if the login call fails, reload so the operator
+                          // lands on the login form rather than a broken page.
+                        }
                         window.location.reload();
                       }
                     }}

--- a/web/src/components/settings/SecurityTab.test.ts
+++ b/web/src/components/settings/SecurityTab.test.ts
@@ -26,6 +26,7 @@ vi.mock('$lib/api', () => ({
 
 // Mock authStore
 const mockChangePassword = vi.fn();
+const mockLogin = vi.fn().mockResolvedValue({ success: true });
 const { mockIsAdmin, mockCurrentUser } = vi.hoisted(() => {
   return {
     mockIsAdmin: { value: true },
@@ -41,6 +42,7 @@ vi.mock('$lib/authStore', async () => {
     isAdmin: { subscribe: isAdminBase.subscribe },
     currentUser: { subscribe: currentUserBase.subscribe },
     changePassword: (...args: unknown[]) => mockChangePassword(...args),
+    login: (...args: unknown[]) => mockLogin(...args),
   };
 });
 
@@ -248,6 +250,59 @@ describe('SecurityTab', () => {
 
       // The Update button should not be visible
       expect(screen.queryByRole('button', { name: /update method/i })).not.toBeInTheDocument();
+    });
+
+    // #25: enabling built-in auth must NOT stash the plaintext password in
+    // web storage for an after-reload auto-login. It logs in first (setting
+    // the session cookie) and then reloads.
+    it('logs in before reload and never writes the password to sessionStorage', async () => {
+      const reloadMock = vi.fn();
+      const origLocation = window.location;
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...origLocation, reload: reloadMock },
+      });
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+      try {
+        // On mount there are no users (so the first-user form shows); after
+        // the user is created, loadSecurityUsers() re-fetches and must return
+        // the new user so the handler proceeds past its securityUsers guard.
+        mockListUsers.mockReset();
+        mockListUsers
+          .mockResolvedValueOnce([])
+          .mockResolvedValue([{ username: 'admin', role: 'admin', email: '', display_name: '' }]);
+        const config = makeConfig({ method: 'none' });
+        render(SecurityTab, { props: { localConfig: config } });
+
+        // Select the built-in (password) method so the first-user form shows.
+        await waitFor(() => {
+          expect(screen.getByText('Password authentication')).toBeInTheDocument();
+        });
+        await fireEvent.click(screen.getByText('Password authentication').closest('button')!);
+
+        const userInput = await screen.findByLabelText('Username');
+        const passInput = document.getElementById('setup-password') as HTMLInputElement;
+        await fireEvent.input(userInput, { target: { value: 'admin' } });
+        await fireEvent.input(passInput, { target: { value: 'sup3rsecret!' } });
+
+        await fireEvent.click(screen.getByRole('button', { name: /create user & enable/i }));
+
+        // login() is called with the just-entered credentials, before reload.
+        await waitFor(() => {
+          expect(mockLogin).toHaveBeenCalledWith('admin', 'sup3rsecret!', true);
+        });
+        expect(reloadMock).toHaveBeenCalled();
+
+        // The password must never be written to storage under any key.
+        for (const call of setItemSpy.mock.calls) {
+          expect(String(call[1])).not.toContain('sup3rsecret!');
+        }
+        expect(setItemSpy).not.toHaveBeenCalledWith('muximux_auto_login', expect.anything());
+      } finally {
+        setItemSpy.mockRestore();
+        Object.defineProperty(window, 'location', { configurable: true, value: origLocation });
+      }
     });
   });
 

--- a/web/src/lib/changelog.test.ts
+++ b/web/src/lib/changelog.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { renderChangelog } from './changelog';
+
+describe('renderChangelog', () => {
+  it('renders ordinary markdown to HTML', async () => {
+    const html = await renderChangelog('# Release 1.0\n\n- Added a thing');
+    expect(html).toContain('<h1');
+    expect(html).toContain('Release 1.0');
+    expect(html).toContain('<li>');
+  });
+
+  it('strips <script> tags from untrusted changelog HTML', async () => {
+    const html = await renderChangelog('# Notes\n\n<script>alert(document.domain)</script>');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('alert(document.domain)');
+    // The legitimate heading still survives sanitization.
+    expect(html).toContain('Notes');
+  });
+
+  it('strips event-handler attributes and javascript: URLs', async () => {
+    const html = await renderChangelog('<img src=x onerror="alert(1)">\n\n[click](javascript:alert(1))');
+    expect(html.toLowerCase()).not.toContain('onerror');
+    expect(html.toLowerCase()).not.toContain('javascript:');
+  });
+
+  it('returns empty string for empty input', async () => {
+    expect(await renderChangelog('')).toBe('');
+  });
+});

--- a/web/src/lib/changelog.ts
+++ b/web/src/lib/changelog.ts
@@ -1,0 +1,20 @@
+// Renders release-notes markdown to HTML for the About tab's changelog.
+//
+// The changelog arrives from the remote update check (checkForUpdates),
+// so it is untrusted input that ends up in an {@html ...} block. `marked`
+// passes raw HTML through and can emit javascript: URLs from markdown
+// links, so the parsed output MUST be sanitized before it reaches the
+// DOM. DOMPurify strips scripts, event-handler attributes, and dangerous
+// URL schemes while leaving ordinary formatting intact.
+//
+// Both `marked` and `dompurify` are dynamically imported so their weight
+// stays out of the Settings chunk until a changelog actually renders.
+export async function renderChangelog(markdown: string): Promise<string> {
+  if (!markdown) return '';
+  const [{ marked }, { default: DOMPurify }] = await Promise.all([
+    import('marked'),
+    import('dompurify'),
+  ]);
+  const rawHtml = String(marked.parse(markdown));
+  return DOMPurify.sanitize(rawHtml);
+}

--- a/web/src/lib/focusTrap.test.ts
+++ b/web/src/lib/focusTrap.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { focusTrap } from './focusTrap';
+
+describe('focusTrap', () => {
+  let outside: HTMLButtonElement;
+  let dialog: HTMLDivElement;
+  let first: HTMLButtonElement;
+  let last: HTMLButtonElement;
+
+  beforeEach(() => {
+    outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+    outside.focus(); // pretend this had focus before the dialog opened
+
+    dialog = document.createElement('div');
+    dialog.tabIndex = -1;
+    first = document.createElement('button');
+    first.textContent = 'first';
+    last = document.createElement('button');
+    last.textContent = 'last';
+    dialog.append(first, last);
+    document.body.appendChild(dialog);
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('moves focus to the first focusable element on mount', () => {
+    focusTrap(dialog);
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('wraps Tab from the last element back to the first', () => {
+    focusTrap(dialog);
+    last.focus();
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    dialog.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('wraps Shift+Tab from the first element back to the last', () => {
+    focusTrap(dialog);
+    first.focus();
+    const ev = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+    dialog.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('restores focus to the previously-focused element on destroy', () => {
+    const handle = focusTrap(dialog);
+    expect(document.activeElement).toBe(first);
+    handle.destroy();
+    expect(document.activeElement).toBe(outside);
+  });
+});

--- a/web/src/lib/focusTrap.test.ts
+++ b/web/src/lib/focusTrap.test.ts
@@ -50,6 +50,15 @@ describe('focusTrap', () => {
     expect(document.activeElement).toBe(last);
   });
 
+  it('calls onEscape when Escape is pressed inside the dialog', () => {
+    let escaped = 0;
+    focusTrap(dialog, { onEscape: () => { escaped += 1; } });
+    const ev = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    dialog.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+    expect(escaped).toBe(1);
+  });
+
   it('restores focus to the previously-focused element on destroy', () => {
     const handle = focusTrap(dialog);
     expect(document.activeElement).toBe(first);

--- a/web/src/lib/focusTrap.ts
+++ b/web/src/lib/focusTrap.ts
@@ -23,10 +23,21 @@ function focusableWithin(node: HTMLElement): HTMLElement[] {
   );
 }
 
-export function focusTrap(node: HTMLElement) {
+export interface FocusTrapParams {
+  // Called when Escape is pressed while focus is inside the dialog. Wire it
+  // to the modal's close handler so the dialog is dismissable by keyboard.
+  onEscape?: () => void;
+}
+
+export function focusTrap(node: HTMLElement, params: FocusTrapParams = {}) {
   const previouslyFocused = document.activeElement as HTMLElement | null;
 
   function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && params.onEscape) {
+      e.preventDefault();
+      params.onEscape();
+      return;
+    }
     if (e.key !== 'Tab') return;
     const focusable = focusableWithin(node);
     if (focusable.length === 0) {
@@ -57,6 +68,9 @@ export function focusTrap(node: HTMLElement) {
   node.addEventListener('keydown', handleKeydown);
 
   return {
+    update(next: FocusTrapParams = {}) {
+      params = next;
+    },
     destroy() {
       node.removeEventListener('keydown', handleKeydown);
       // Restore focus to where it was before the dialog opened, so keyboard

--- a/web/src/lib/focusTrap.ts
+++ b/web/src/lib/focusTrap.ts
@@ -1,0 +1,69 @@
+// focusTrap is a Svelte action for modal dialogs. It keeps keyboard focus
+// inside the node while it is mounted, moves focus into the dialog on open,
+// and restores focus to the previously-focused element on close. Pair it
+// with role="dialog" + aria-modal="true" and an Escape-to-close handler for
+// an accessible modal.
+//
+// Visibility is judged by the `hidden` attribute / `disabled` rather than
+// layout (offsetParent), so the behaviour is identical under jsdom (which
+// has no layout) and in a real browser.
+
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function focusableWithin(node: HTMLElement): HTMLElement[] {
+  return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+    (el) => !el.hasAttribute('hidden') && el.closest('[hidden]') === null,
+  );
+}
+
+export function focusTrap(node: HTMLElement) {
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Tab') return;
+    const focusable = focusableWithin(node);
+    if (focusable.length === 0) {
+      // Nothing to focus inside: keep focus on the dialog itself.
+      e.preventDefault();
+      node.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey) {
+      if (active === first || !node.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (active === last || !node.contains(active)) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  // Move focus into the dialog. Prefer the first focusable control; fall
+  // back to the dialog node (which needs tabindex="-1" to be focusable).
+  const initial = focusableWithin(node);
+  (initial[0] ?? node).focus();
+
+  node.addEventListener('keydown', handleKeydown);
+
+  return {
+    destroy() {
+      node.removeEventListener('keydown', handleKeydown);
+      // Restore focus to where it was before the dialog opened, so keyboard
+      // users are not dumped at the top of the document.
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+    },
+  };
+}

--- a/web/src/lib/safeColor.test.ts
+++ b/web/src/lib/safeColor.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { safeColor } from './safeColor';
+
+describe('safeColor', () => {
+  it('accepts valid CSS colour forms unchanged', () => {
+    for (const c of ['#fff', '#ffffff', '#ffffffff', 'red', 'transparent', 'currentColor',
+      'rgb(1,2,3)', 'rgba(1,2,3,0.5)', 'hsl(120, 50%, 50%)', 'var(--accent-primary)']) {
+      expect(safeColor(c)).toBe(c);
+    }
+  });
+
+  it('trims surrounding whitespace on a valid colour', () => {
+    expect(safeColor('  #abc  ')).toBe('#abc');
+  });
+
+  it('rejects CSS injection and returns the fallback', () => {
+    for (const bad of [
+      'red; background-image: url(https://evil/x)',
+      '#fff);}body{display:none',
+      'url(javascript:alert(1))',
+      'expression(alert(1))',
+      'red /* comment */',
+      'var(--x); position:fixed',
+      '',
+    ]) {
+      expect(safeColor(bad, 'FALLBACK')).toBe('FALLBACK');
+    }
+  });
+
+  it('returns the fallback for null/undefined', () => {
+    expect(safeColor(null, 'x')).toBe('x');
+    expect(safeColor(undefined, 'x')).toBe('x');
+    expect(safeColor('')).toBe('');
+  });
+});

--- a/web/src/lib/safeColor.ts
+++ b/web/src/lib/safeColor.ts
@@ -1,0 +1,26 @@
+// safeColor validates a user-supplied colour before it is interpolated into
+// an inline `style` attribute. App / group / icon colours can be set by an
+// admin or imported from Docker labels (attacker-influenceable), and Svelte
+// only HTML-escapes an attribute value -- it does not stop a value like
+// `red; background-image: url(https://evil/x)` from injecting extra CSS
+// declarations once inside the style string. This returns the colour only
+// when it matches a known-safe CSS colour form, and an empty string
+// otherwise so the caller falls back to its default.
+//
+// Accepted forms: #hex (3/4/6/8), rgb()/rgba(), hsl()/hsla(), var(--token),
+// and bare CSS keyword names (letters only, e.g. "red", "transparent").
+const SAFE_COLOR = new RegExp(
+  [
+    '^#[0-9a-fA-F]{3,8}$', // #rgb .. #rrggbbaa
+    '^rgba?\\([0-9.,%/\\s]+\\)$', // rgb() / rgba()
+    '^hsla?\\([0-9.,%/\\sdeg]+\\)$', // hsl() / hsla()
+    '^var\\(--[a-zA-Z0-9-]+\\)$', // var(--token)
+    '^[a-zA-Z]+$', // keyword: red, transparent, currentColor, ...
+  ].join('|'),
+);
+
+export function safeColor(color: string | null | undefined, fallback = ''): string {
+  if (!color) return fallback;
+  const trimmed = color.trim();
+  return SAFE_COLOR.test(trimmed) ? trimmed : fallback;
+}


### PR DESCRIPTION
A broad fresh-eyes review and hardening pass across the whole stack -- reverse proxy, Docker discovery, auth, config persistence, and the frontend. One new feature (identity forwarding to proxied backends); everything else tightens behaviour that already ships. Drop-in: no config changes required.

This supersedes #389 (the 3.2.2 reliability/security hotfix) -- its fixes are folded into this release, so #389 can be closed.

## Highlights

### New feature
- **Identity forwarding to proxied backends.** Custom proxy headers expand `${user}`, `${role}`, `${email}`, `${display_name}`, `${groups}` (CR/LF/NUL-sanitized), so a backend can trust the dashboard's auth instead of running its own login. (#388)

### Security
- API keys hashed with **SHA-256** instead of bcrypt (bcrypt-on-attacker-input was an unauthenticated CPU-DoS on the `X-Api-Key` path); legacy hashes **auto-upgrade on first use**.
- Uploaded icons are **type-checked by their bytes**, not the client Content-Type (closes an HTML-as-SVG stored-XSS path).
- The remote changelog is **sanitized with DOMPurify** before `{@html}` rendering.
- `multipart/form-data` is no longer a stand-alone CSRF marker (it is CORS-simple); uploads require `X-Requested-With`.
- Docker lifecycle actions enforce **per-app access**, not just the capability gate.
- `strip_frame_blockers` scopes `frame-ancestors` to the dashboard origin instead of stripping framing protection wholesale (clickjacking).
- Built-in users' group memberships are carried on the session, so gateway `allowed_groups` gates accept them.
- `http_action` stops following redirects (SSRF); deleting a user revokes their sessions immediately; slowloris read timeouts restored.
- The plaintext password is no longer stashed in `sessionStorage` when enabling built-in auth.

### Reliability
- Auto-import `sync` no longer wipes apps on a failed/empty scan (removal **hysteresis** + skip-on-error).
- A Docker lifecycle state write is no longer clobbered by a concurrent poll tick.
- Oversized proxied responses forwarded in full (no 50 MB truncation); `Content-Encoding` classified by whole token; inline `<script>`/`<style>` excluded from path rewriting.
- App create/update validated before persisting (an invalid `http_action` can't block the next boot); config-export data race fixed; temp-file cleanup on failed save; shutdown log ordering.

### Accessibility & UX
- App add/edit modals are accessible dialogs with **focus trapping** and focus restore.
- The Docker action confirm modal stays open with progress while the action runs, and closes when it resolves.

## Testing & method

Each change was written **failing-test-first**, and every non-trivial change (concurrency, proxy engine, auth) went through an adversarial review whose findings were fixed before commit.

Full gate is green on this branch: `gofmt` clean, all Go tests pass, `golangci-lint` 0 issues, 1830 frontend tests pass, typecheck 0 errors, frontend builds.

See `CHANGELOG.md` for the complete `[3.3.0]` entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forward authenticated identity and group info through reverse-proxy headers using safe per-request templating.
  * In-place runtime updates for Docker discovery configuration.
* **Security**
  * Migrated API keys toward SHA-256 with automatic legacy upgrades.
  * Hardened reverse-proxy behavior (no redirect following, safer header/CSP handling, better response rewriting rules).
  * Strengthened icon and About-tab changelog sanitization; tightened per-app access for health and Docker actions; immediate session revocation on user deletion.
* **Bug Fixes**
  * Improved reliability for Docker discovery/poller syncing and more correct large/encoded proxied responses.
* **Documentation & Accessibility**
  * Updated reverse-proxy documentation and improved modal keyboard accessibility (focus trapping, Escape handling, loading lock).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->