### PR TITLE
Run CI on Node 26 to match the container build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -176,7 +176,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The primary development environment for Muximux is Claude Code with MCP servers 
 ## Prerequisites
 
 - **Go** 1.26+ (check with `go version`)
-- **Node.js** 20+ with npm (check with `node --version`)
+- **Node.js** 22+ with npm (check with `node --version`) -- CI and the container build both use Node 26
 - **golangci-lint v2** (`go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`) -- `.golangci.yml` is a v2 config and v1 cannot parse it
 
 ## Getting Started


### PR DESCRIPTION
CI pinned Node 20 in four places (`ci.yml` ×3, `release.yml`, `security.yml`) while `Dockerfile:18` builds the frontend on `node:26-alpine`. The published image was therefore compiled on a Node six majors newer than the one the test suite validated against. Node 20 also left maintenance in April 2026, so CI was running an unsupported runtime.

This aligns the workflows with the Dockerfile.

## Knock-on effects

- **Unblocks #416** (jsdom 29 -> 30). jsdom 30 declares `engines: node ^22.22.2 || ^24.15.0 || >=26.0.0` and currently fails on Node 20 with `TypeError: webidl.util.markAsUncloneable is not a function`, thrown from undici inside `jsdom/lib/api.js`.
- **Legitimises #417** (jest-dom 6 -> 7), already merged. It declares `engines: node >=22` and passed only because there is no `.npmrc`, so `engines` is advisory and npm warns rather than failing.
- Does not affect #418 (TypeScript 7), which is blocked separately by `svelte-check@4.7.4` peering `typescript: ^5.0.0 || ^6.0.0`.

## Choice of 26 over 24

26 matches the Dockerfile, which is the parity this change is about. Node 24 is the current Active LTS and would be the more conservative pick, but it would leave the build and test runtimes on different majors, which is the actual problem here. Happy to switch to 24 if you would rather track LTS and bump the Dockerfile down to match.

`CONTRIBUTING.md` prerequisite updated from "Node.js 20+" to "22+", noting that CI and the container build both use 26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use Node.js 26 for linting, testing, builds, releases, and security checks.

* **Documentation**
  * Updated contribution guidelines to require Node.js 22 or newer and noted that CI and container builds use Node.js 26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->