### PR TITLE
Bump both CodeQL action pins together and group them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,11 @@ updates:
     labels:
       - dependencies
       - ci
+    groups:
+      # init and analyze are subpaths of one action and must run the same
+      # version, or analyze fails with "Loaded a configuration file for
+      # version X, but running version Y". Ungrouped, Dependabot raises one
+      # PR per subpath and neither can pass CI alone.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,12 +30,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4.37.4
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Supersedes #421 and #422.

`github/codeql-action/init` and `github/codeql-action/analyze` are subpaths of a single action and share one commit SHA, so they must run the same version. Dependabot raised them as two PRs, and each fails on its own:

```
##[error] Loaded a configuration file for version 4.37.4, but running version 4.37.3
```

Merging either alone would have left `main` failing CodeQL until the other landed.

## Changes

- Both pins move to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (verified as `v4.37.4` via the GitHub API), matching what #421 and #422 each proposed for their half.
- `dependabot.yml` gains a `codeql-action` group on the `github-actions` ecosystem so future bumps arrive as one PR rather than splitting again.

## Also

The `ci` and `frontend` labels have been created. Dependabot had been commenting "The following labels could not be found" on every PR for those two ecosystems, so `github-actions` and `npm` updates were arriving unlabelled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped CodeQL action updates into a single dependency update.
  * Updated CodeQL analysis actions to version 4.37.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->