### PR TITLE
Recognise custom and URL icons for the overview button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Muximux are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Custom uploads work as the overview button icon.** Selecting a custom
+  icon for the overview button in General settings appeared to do nothing:
+  the card stayed unhighlighted and the navigation kept showing the logo.
+  Custom icons are identified by `file` rather than `name`, and every
+  overview-button check tested `name`, so custom and URL icons were never
+  recognised. The checks now go through the same resolver that renders
+  icons. (#437)
+
 ## [3.3.3] - 2026-07-29
 
 A first-run release: the setup step every new install begins with was

--- a/web/src/components/AppForm.svelte
+++ b/web/src/components/AppForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { iconLabel } from '$lib/iconUrl';
   import type { App, Group } from '$lib/types';
   import { openModes, IFRAME_PERMISSIONS } from '$lib/constants';
   import { slugify, findSlugConflict } from '$lib/slug';
@@ -219,7 +220,7 @@
           class="btn btn-secondary btn-sm w-full text-start"
           onclick={() => onopenicon?.()}
         >
-          {app.icon?.name || m.appForm_chooseIcon()}
+          {iconLabel(app.icon) || m.appForm_chooseIcon()}
         </button>
         <p class="text-xs text-text-muted mt-1">
           {app.icon?.type === 'dashboard' ? m.appForm_iconTypeDashboard() : app.icon?.type === 'lucide' ? m.appForm_iconTypeLucide() : app.icon?.type === 'custom' ? m.appForm_iconTypeCustom() : app.icon?.type === 'url' ? m.appForm_iconTypeUrl() : m.appForm_iconTypeNone()}

--- a/web/src/components/Navigation.svelte
+++ b/web/src/components/Navigation.svelte
@@ -1008,7 +1008,7 @@
                 style={hasActiveApp && config.navigation.show_app_colors ? `border-bottom: 2px solid ${groupConfig?.color || currentApp?.color || 'var(--accent-primary)'}` : ''}
                 onclick={() => openGroupDropdown = openGroupDropdown === groupName ? null : groupName}
               >
-                {#if groupConfig?.icon?.name}
+                {#if hasIcon(groupConfig?.icon)}
                   <AppIcon icon={groupConfig.icon} name={groupName} color={groupConfig.color || ''} size="sm" scale={iconScale} showBackground={false} />
                 {/if}
                 <span>{groupName}</span>
@@ -1080,7 +1080,7 @@
                 title={groupName}
                 aria-label={groupName}
               >
-                {#if groupConfig?.icon?.name}
+                {#if hasIcon(groupConfig?.icon)}
                   <span style="opacity: {hoveredGroup === groupName ? '1' : '0.4'}; transition: opacity 0.15s ease;">
                     <AppIcon icon={groupConfig.icon} name={groupName} color={groupConfig.color || ''} size="sm" scale={iconScale * 0.85} showBackground={false} />
                   </span>
@@ -1307,7 +1307,7 @@
             style="pointer-events: {isCollapsed ? 'none' : 'auto'};"
           >
             <div class="flex-shrink-0 flex items-center justify-center" style="width: {collapsedStripWidth}px;">
-              {#if groupConfig?.icon?.name}
+              {#if hasIcon(groupConfig?.icon)}
                 <AppIcon icon={groupConfig.icon} name={groupName} color={groupConfig.color || '#374151'} size="sm" scale={iconScale} showBackground={config.navigation.show_icon_background} />
               {:else if groupConfig?.color}
                 <span class="w-2 h-2 rounded-full" style="background-color: {groupConfig.color}"></span>
@@ -1321,7 +1321,7 @@
               {/if}
             </div>
             <div class="flex items-center overflow-hidden flex-1 min-w-0" style="opacity: {isCollapsed ? '0' : '1'}; transition: opacity 0.15s ease;">
-              {#if groupConfig?.icon?.name || groupConfig?.color}
+              {#if hasIcon(groupConfig?.icon) || groupConfig?.color}
                 <svg
                   class="w-3 h-3 transition-transform {expandedGroups[groupName] ? 'rotate-90' : ''} me-1 flex-shrink-0"
                   fill="none" viewBox="0 0 24 24" stroke="currentColor"
@@ -1732,7 +1732,7 @@
             style="pointer-events: {isCollapsedRight ? 'none' : 'auto'};"
           >
             <div class="flex-shrink-0 flex items-center justify-center" style="width: {collapsedStripWidth}px;">
-              {#if groupConfig?.icon?.name}
+              {#if hasIcon(groupConfig?.icon)}
                 <AppIcon icon={groupConfig.icon} name={groupName} color={groupConfig.color || '#374151'} size="sm" scale={iconScale} showBackground={config.navigation.show_icon_background} />
               {:else if groupConfig?.color}
                 <span class="w-2 h-2 rounded-full" style="background-color: {groupConfig.color}"></span>
@@ -1746,7 +1746,7 @@
               {/if}
             </div>
             <div class="flex items-center overflow-hidden flex-1 min-w-0" style="opacity: {isCollapsedRight ? '0' : '1'}; transition: opacity 0.15s ease;">
-              {#if groupConfig?.icon?.name || groupConfig?.color}
+              {#if hasIcon(groupConfig?.icon) || groupConfig?.color}
                 <svg
                   class="w-3 h-3 transition-transform {expandedGroups[groupName] ? 'rotate-90' : ''} me-1 flex-shrink-0"
                   fill="none" viewBox="0 0 24 24" stroke="currentColor"
@@ -2137,7 +2137,7 @@
                 style={hasActiveApp && config.navigation.show_app_colors ? `border-top: 2px solid ${groupConfig?.color || currentApp?.color || 'var(--accent-primary)'}` : ''}
                 onclick={() => openGroupDropdown = openGroupDropdown === groupName ? null : groupName}
               >
-                {#if groupConfig?.icon?.name}
+                {#if hasIcon(groupConfig?.icon)}
                   <AppIcon icon={groupConfig.icon} name={groupName} color={groupConfig.color || ''} size="sm" scale={iconScale} showBackground={false} />
                 {/if}
                 <span>{groupName}</span>
@@ -2208,7 +2208,7 @@
                 title={groupName}
                 aria-label={groupName}
               >
-                {#if groupConfig?.icon?.name}
+                {#if hasIcon(groupConfig?.icon)}
                   <span style="opacity: {hoveredGroup === groupName ? '1' : '0.4'}; transition: opacity 0.15s ease;">
                     <AppIcon icon={groupConfig.icon} name={groupName} color={groupConfig.color || ''} size="sm" scale={iconScale * 0.85} showBackground={false} />
                   </span>
@@ -2373,7 +2373,7 @@
                 onclick={() => toggleGroup(groupName)}
               >
                 <div class="flex-shrink-0 flex items-center justify-center w-6">
-                  {#if groupConfig?.icon?.name}
+                  {#if hasIcon(groupConfig?.icon)}
                     <AppIcon icon={groupConfig.icon} name={groupName} color={groupConfig.color || '#374151'} size="sm" scale={iconScale} showBackground={config.navigation.show_icon_background} />
                   {:else if groupConfig?.color}
                     <span class="w-2 h-2 rounded-full" style="background-color: {groupConfig.color}"></span>
@@ -2387,7 +2387,7 @@
                   {/if}
                 </div>
                 <div class="flex items-center flex-1 min-w-0 ms-1">
-                  {#if groupConfig?.icon?.name || groupConfig?.color}
+                  {#if hasIcon(groupConfig?.icon) || groupConfig?.color}
                     <svg
                       class="w-3 h-3 transition-transform {expandedGroups[groupName] ? 'rotate-90' : ''} me-1 flex-shrink-0"
                       fill="none" viewBox="0 0 24 24" stroke="currentColor"

--- a/web/src/components/Navigation.svelte
+++ b/web/src/components/Navigation.svelte
@@ -2,6 +2,7 @@
   import { onMount, untrack } from 'svelte';
   import type { App, Config, Group } from '$lib/types';
   import AppIcon from './AppIcon.svelte';
+  import { hasIcon } from '$lib/iconUrl';
   import HealthIndicator from './HealthIndicator.svelte';
   import DockerLogo from './DockerLogo.svelte';
   import DockerStatePill from './DockerStatePill.svelte';
@@ -951,7 +952,7 @@
     >
       <!-- Logo — fixed -->
       {#if showHomeButton}
-        {#if homeIcon?.name}
+        {#if hasIcon(homeIcon)}
           <button
             class="flex-shrink-0 p-1 rounded-md hover:bg-bg-hover transition-colors"
             style="color: var(--accent-primary); opacity: {showSplash ? '0.6' : '1'}; transition: opacity 0.2s ease;"
@@ -1226,7 +1227,7 @@
     >
     <!-- Header — fixed height, logo scales via CSS transform for smooth animation -->
     {#if showHomeButton}
-      {#if homeIcon?.name}
+      {#if hasIcon(homeIcon)}
         <div class="border-b border-border flex items-center justify-center overflow-hidden"
              style="height: {isCollapsed ? `${collapsedStripWidth}px` : '52px'};">
           <button
@@ -1651,7 +1652,7 @@
     >
     <!-- Header — fixed height, logo scales via CSS transform for smooth animation -->
     {#if showHomeButton}
-      {#if homeIcon?.name}
+      {#if hasIcon(homeIcon)}
         <div class="border-b border-border flex items-center justify-center overflow-hidden"
              style="height: {isCollapsedRight ? `${collapsedStripWidth}px` : '52px'};">
           <button
@@ -2080,7 +2081,7 @@
     >
       <!-- Logo — fixed -->
       {#if showHomeButton}
-        {#if homeIcon?.name}
+        {#if hasIcon(homeIcon)}
           <button
             class="flex-shrink-0 p-1 rounded-md hover:bg-bg-hover transition-colors"
             style="color: var(--accent-primary); opacity: {showSplash ? '0.6' : '1'}; transition: opacity 0.2s ease;"
@@ -2447,7 +2448,7 @@
         <!-- Footer — all action buttons in one row -->
         <div class="border-t px-2 py-2 flex items-center gap-1 shrink-0" style="border-color: var(--border-subtle);">
           {#if showHomeButton}
-            {#if homeIcon?.name}
+            {#if hasIcon(homeIcon)}
               <button
                 class="p-1.5 rounded-md hover:bg-bg-hover transition-colors"
                 style="color: var(--accent-primary); opacity: {showSplash ? '0.6' : '1'}; transition: opacity 0.2s ease;"

--- a/web/src/components/Settings.svelte
+++ b/web/src/components/Settings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { iconLabel } from '$lib/iconUrl';
   import { onMount, untrack } from 'svelte';
   import { fade, fly } from 'svelte/transition';
   import { type App, type Config, type Group, makeApp, makeGroup, stampAppId, stampGroupId } from '$lib/types';
@@ -879,7 +880,7 @@
               class="btn btn-secondary btn-sm flex-1 text-start"
               onclick={() => openIconBrowser('newGroup')}
             >
-              {newGroup.icon?.name || m.settings_chooseIcon()}
+              {iconLabel(newGroup.icon) || m.settings_chooseIcon()}
             </button>
           </div>
         </div>
@@ -1029,7 +1030,7 @@
                 class="btn btn-secondary btn-sm w-full text-start"
                 onclick={() => openIconBrowser('editGroup')}
               >
-                {editingGroup.icon?.name || m.settings_chooseIcon()}
+                {iconLabel(editingGroup.icon) || m.settings_chooseIcon()}
               </button>
               <p class="text-xs text-text-muted mt-1">
                 {editingGroup.icon?.type === 'dashboard' ? m.settings_dashboardIcon() : editingGroup.icon?.type || m.settings_noIconSet()}

--- a/web/src/components/settings/AppsTab.svelte
+++ b/web/src/components/settings/AppsTab.svelte
@@ -3,6 +3,7 @@
   import { flip } from 'svelte/animate';
   import { type App, type Group, type DiscoveryDockerStatus, stampAppId } from '$lib/types';
   import AppIcon from '../AppIcon.svelte';
+  import { hasIcon } from '$lib/iconUrl';
   import { dndzone, type DndEvent } from 'svelte-dnd-action';
   import * as m from '$lib/paraglide/messages.js';
   import { fetchDiscoveryDockerStatus } from '$lib/api';
@@ -386,7 +387,7 @@
 
           <!-- Group icon -->
           <div class="flex-shrink-0">
-            {#if group.icon?.name}
+            {#if hasIcon(group.icon)}
               <AppIcon icon={group.icon} name={group.name} color={group.color || '#374151'} size="sm" showBackground={true} />
             {:else}
               <span class="w-6 h-6 rounded flex-shrink-0 block" style="background-color: {group.color || '#374151'}"></span>

--- a/web/src/components/settings/GeneralTab.svelte
+++ b/web/src/components/settings/GeneralTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { App, Config } from '$lib/types';
   import AppIcon from '../AppIcon.svelte';
+  import { hasIcon } from '$lib/iconUrl';
   import MuximuxLogo from '../MuximuxLogo.svelte';
   import LocaleSelect from '../LocaleSelect.svelte';
   import * as m from '$lib/paraglide/messages.js';
@@ -179,7 +180,7 @@
         </button>
         <!-- Muximux Logo -->
         <button
-          class="flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-colors {localConfig.navigation.show_home_button !== false && localConfig.navigation.show_logo && !localConfig.navigation.home_icon?.name ? 'border-brand-500 bg-brand-500/10' : 'border-transparent bg-bg-surface hover:bg-bg-hover'}"
+          class="flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-colors {localConfig.navigation.show_home_button !== false && localConfig.navigation.show_logo && !hasIcon(localConfig.navigation.home_icon) ? 'border-brand-500 bg-brand-500/10' : 'border-transparent bg-bg-surface hover:bg-bg-hover'}"
           onclick={() => { localConfig.navigation.show_home_button = true; localConfig.navigation.show_logo = true; localConfig.navigation.home_icon = undefined; }}
         >
           <MuximuxLogo height="20" />
@@ -187,7 +188,7 @@
         </button>
         <!-- House Icon -->
         <button
-          class="flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-colors {localConfig.navigation.show_home_button !== false && !localConfig.navigation.show_logo && !localConfig.navigation.home_icon?.name ? 'border-brand-500 bg-brand-500/10' : 'border-transparent bg-bg-surface hover:bg-bg-hover'}"
+          class="flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-colors {localConfig.navigation.show_home_button !== false && !localConfig.navigation.show_logo && !hasIcon(localConfig.navigation.home_icon) ? 'border-brand-500 bg-brand-500/10' : 'border-transparent bg-bg-surface hover:bg-bg-hover'}"
           onclick={() => { localConfig.navigation.show_home_button = true; localConfig.navigation.show_logo = false; localConfig.navigation.home_icon = undefined; }}
         >
           <svg class="w-5 h-5" style="color: var(--accent-primary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -197,10 +198,10 @@
         </button>
         <!-- Custom Icon -->
         <button
-          class="flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-colors {localConfig.navigation.show_home_button !== false && localConfig.navigation.home_icon?.name ? 'border-brand-500 bg-brand-500/10' : 'border-transparent bg-bg-surface hover:bg-bg-hover'}"
+          class="flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-colors {localConfig.navigation.show_home_button !== false && hasIcon(localConfig.navigation.home_icon) ? 'border-brand-500 bg-brand-500/10' : 'border-transparent bg-bg-surface hover:bg-bg-hover'}"
           onclick={() => { localConfig.navigation.show_home_button = true; onopenhomeicon?.(); }}
         >
-          {#if localConfig.navigation.home_icon?.name}
+          {#if hasIcon(localConfig.navigation.home_icon)}
             <AppIcon icon={localConfig.navigation.home_icon} name={localConfig.title} color="" size="sm" showBackground={false} />
           {:else}
             <svg class="w-5 h-5 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/web/src/lib/iconUrl.test.ts
+++ b/web/src/lib/iconUrl.test.ts
@@ -3,7 +3,7 @@ import type { AppIcon } from './types';
 
 vi.mock('./api', () => ({ getBase: () => '/base' }));
 
-import { resolveIconUrl, hasIcon } from './iconUrl';
+import { resolveIconUrl, hasIcon, iconLabel } from './iconUrl';
 
 describe('resolveIconUrl', () => {
   it('returns null for missing icon or missing identifiers', () => {
@@ -49,5 +49,23 @@ describe('hasIcon', () => {
   it('is false for undefined or null', () => {
     expect(hasIcon(undefined)).toBe(false);
     expect(hasIcon(null)).toBe(false);
+  });
+});
+
+describe('iconLabel', () => {
+  it('returns the name for dashboard and lucide icons', () => {
+    expect(iconLabel({ type: 'dashboard', name: 'plex' })).toBe('plex');
+    expect(iconLabel({ type: 'lucide', name: 'house' })).toBe('house');
+  });
+
+  it('returns the filename for a custom upload and the url for a remote icon', () => {
+    expect(iconLabel({ type: 'custom', name: '', file: 'my-logo.png' })).toBe('my-logo.png');
+    expect(iconLabel({ type: 'url', name: '', url: 'https://example.com/i.png' })).toBe('https://example.com/i.png');
+  });
+
+  it('returns null when nothing identifies the icon', () => {
+    expect(iconLabel({ type: 'custom', name: '' })).toBe(null);
+    expect(iconLabel(undefined)).toBe(null);
+    expect(iconLabel(null)).toBe(null);
   });
 });

--- a/web/src/lib/iconUrl.test.ts
+++ b/web/src/lib/iconUrl.test.ts
@@ -3,7 +3,7 @@ import type { AppIcon } from './types';
 
 vi.mock('./api', () => ({ getBase: () => '/base' }));
 
-import { resolveIconUrl } from './iconUrl';
+import { resolveIconUrl, hasIcon } from './iconUrl';
 
 describe('resolveIconUrl', () => {
   it('returns null for missing icon or missing identifiers', () => {
@@ -23,5 +23,31 @@ describe('resolveIconUrl', () => {
     expect(resolveIconUrl({ type: 'custom', file: 'my.png' } as AppIcon)).toBe('/base/icons/custom/my.png');
     expect(resolveIconUrl({ type: 'lucide', name: 'home' } as AppIcon)).toBe('/base/icons/lucide/home.svg');
     expect(resolveIconUrl({ type: 'url', url: 'https://x/y.png' } as AppIcon)).toBe('https://x/y.png');
+  });
+});
+
+describe('hasIcon', () => {
+  it('is true for a custom upload identified by file, even with an empty name (#437)', () => {
+    expect(hasIcon({ type: 'custom', name: '', file: 'my-logo.png' })).toBe(true);
+  });
+
+  it('is true for a remote icon identified by url', () => {
+    expect(hasIcon({ type: 'url', name: '', url: 'https://example.com/i.png' })).toBe(true);
+  });
+
+  it('is true for dashboard and lucide icons identified by name', () => {
+    expect(hasIcon({ type: 'dashboard', name: 'plex' })).toBe(true);
+    expect(hasIcon({ type: 'lucide', name: 'house' })).toBe(true);
+  });
+
+  it('is false when the identifying field for the type is missing', () => {
+    expect(hasIcon({ type: 'custom', name: 'ignored' })).toBe(false);
+    expect(hasIcon({ type: 'dashboard', name: '' })).toBe(false);
+    expect(hasIcon({ type: 'url' })).toBe(false);
+  });
+
+  it('is false for undefined or null', () => {
+    expect(hasIcon(undefined)).toBe(false);
+    expect(hasIcon(null)).toBe(false);
   });
 });

--- a/web/src/lib/iconUrl.ts
+++ b/web/src/lib/iconUrl.ts
@@ -39,3 +39,13 @@ export function resolveIconUrl(icon: AppIcon | undefined | null): string | null 
 export function hasIcon(icon: AppIcon | undefined | null): icon is AppIcon {
   return resolveIconUrl(icon) !== null;
 }
+
+/**
+ * Human-readable identifier for an icon config, for labels such as the
+ * "choose icon" button: the dashboard/lucide name, the custom upload's
+ * filename, or the remote URL. Null when nothing is set.
+ */
+export function iconLabel(icon: AppIcon | undefined | null): string | null {
+  if (!icon) return null;
+  return icon.name || icon.file || icon.url || null;
+}

--- a/web/src/lib/iconUrl.ts
+++ b/web/src/lib/iconUrl.ts
@@ -29,3 +29,13 @@ export function resolveIconUrl(icon: AppIcon | undefined | null): string | null 
       return null;
   }
 }
+
+/**
+ * True when the config names an icon that resolveIconUrl can turn into a URL.
+ * Callers must not test `icon.name` for this: dashboard and lucide icons use
+ * `name`, but custom uploads use `file` and remote icons use `url`, so a
+ * `name` check silently rejects both of those types (#437).
+ */
+export function hasIcon(icon: AppIcon | undefined | null): icon is AppIcon {
+  return resolveIconUrl(icon) !== null;
+}


### PR DESCRIPTION
Fixes #437.

Selecting a custom upload as the overview button icon appeared to do nothing: the Custom card stayed unhighlighted and the navigation kept rendering the logo. The upload itself succeeded, which is why the report reads as the upload being broken.

## Cause

`handleIconSelect` stores custom icons with an empty `name` and the filename in `file` (and URL icons in `url`), but every overview-button check in `GeneralTab.svelte` (4) and `Navigation.svelte` (5) tested `icon.name`. Dashboard and Lucide icons use `name`, so they worked; custom and URL icons were never recognised.

## Fix

`hasIcon`, a type guard built on `resolveIconUrl`, replaces the nine `?.name` checks, so the check and the renderer cannot disagree about what counts as a usable icon. Tests cover all four icon types plus the missing-identifier and null cases.

## Verification

Reproduced in headless Chromium against a build of `main`: upload a PNG in the overview-button picker, select it, save. The Custom card stayed unhighlighted and the nav kept the logo. Same steps against this branch: card highlighted and rendering the icon, nav rendering the custom icon, `home_icon: {type: custom, file: ...}` on disk. A control run selecting a Lucide icon passed on both builds, confirming the failure was type-specific.

Full frontend suite: 71 files, 1901 tests, coverage unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed icon detection for custom uploaded icons in overview buttons.
  - Custom, remote URL, dashboard, and Lucide icons are now recognized consistently.
  - Corrected overview-button highlighting and icon rendering across navigation layouts and settings.
  - Home icons now display correctly in the top bar, sidebars, bottom bar, and floating panel.
  - Icon-selection buttons now display meaningful labels for uploaded files and remote icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->