### PR TITLE
Build on Go 1.26.6 and let govulncheck gate the workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,7 +97,8 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
 
       - name: Run govulncheck
-        # continue-on-error until GO-2026-4923 (disputed bbolt CVE) is
-        # invalidated upstream: https://github.com/golang/vulndb/issues/4938
-        continue-on-error: true
+        # This step gates the workflow. It was continue-on-error while
+        # GO-2026-4923 (a disputed bbolt CVE) was open; that report was
+        # withdrawn on 2026-04-08, and the exemption had since been hiding
+        # two real stdlib findings (GO-2026-6218, GO-2026-6091).
         run: govulncheck ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mescon/muximux/v3
 
-go 1.26.1
+go 1.26.6
 
 require gopkg.in/yaml.v3 v3.0.1
 


### PR DESCRIPTION
`go.mod` pinned `go 1.26.1`, and `actions/setup-go` resolves `go-version-file` to that exact version, so CI and every release since 3.3.0 have been built against a 1.26.1 standard library. The published 3.3.3 `muximux-linux-amd64` reports `go1.26.1`.

Go 1.26.6 fixes two standard-library vulnerabilities that govulncheck reports as reachable from this code:

| ID | CVE | Package | Relevance |
|---|---|---|---|
| GO-2026-6218 | CVE-2026-56860 | `net/url` | quadratic path resolution; Muximux resolves attacker-influenced paths in the embedding proxy |
| GO-2026-6091 | CVE-2026-56858 | `html/template` | JavaScript regexp context tracking; reached via dependencies |

Both were published on 13 August and fixed in 1.26.6.

## Why CI stayed green

The govulncheck step in `security.yml` has been reporting both findings on every run since they were published, but it was marked `continue-on-error: true`. That exemption was added for GO-2026-4923, a disputed bbolt report, which the Go vulnerability database withdrew on 8 April. The exemption outlived its reason and has been hiding real findings for three weeks.

## Changes

- `go.mod`: `go 1.26.1` -> `go 1.26.6`, so the toolchain CI installs carries the fixes. `go mod tidy` is clean.
- `security.yml`: remove `continue-on-error` from the govulncheck step, with a comment recording why it was there and why it is gone.

## Verification

- `govulncheck ./...` under go1.26.6: `No vulnerabilities found.`
- `go build`, `go vet`, `gofmt`, full test suite: clean.
- The pre-push hook (tests, 86.0% coverage, golangci-lint, govulncheck, frontend suite) passed under go1.26.6.

## Follow-up

This warrants a 3.3.4 patch release once merged, since the shipped 3.3.3 binaries and images carry the affected standard library. The changelog entry can go in with the release notes to avoid conflicting with #445, which introduces the `Unreleased` section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Security validation now blocks the workflow when vulnerabilities are detected, improving protection against releases containing known issues.

- **Maintenance**
  - Updated the supported Go toolchain version to improve compatibility, reliability, and access to current language and security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->