### PR TITLE
Make the web manifest relative so the PWA installs under a base path

### DIFF
--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,6 +1,12 @@
 {
+  "id": "./",
   "name": "Muximux",
   "short_name": "Muximux",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "theme_color": "#09090b",
+  "background_color": "#09090b",
   "icons": [
     {
       "src": "./android-chrome-192x192.png",
@@ -20,9 +26,5 @@
       "type": "image/png",
       "purpose": "any maskable"
     }
-  ],
-  "start_url": "/",
-  "theme_color": "#09090b",
-  "background_color": "#09090b",
-  "display": "standalone"
+  ]
 }

--- a/web/src/lib/manifest.test.ts
+++ b/web/src/lib/manifest.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// The manifest is fetched from ./manifest.json relative to wherever the SPA is
+// served, which may be a base_path such as /muximux/. Every URL in it must
+// therefore be relative too: an absolute start_url resolves to the site root,
+// lands outside the manifest's scope, and makes the app uninstallable under
+// a base path (#436).
+describe('web manifest', () => {
+  const manifest = JSON.parse(readFileSync(resolve(__dirname, '../../public/manifest.json'), 'utf8'));
+
+  it('uses relative start_url, scope and id', () => {
+    expect(manifest.start_url).toBe('./');
+    expect(manifest.scope).toBe('./');
+    expect(manifest.id).toBe('./');
+  });
+
+  it('declares installable icons with relative paths', () => {
+    expect(manifest.display).toBe('standalone');
+    const sizes = manifest.icons.map((i: { sizes: string }) => i.sizes);
+    expect(sizes).toEqual(expect.arrayContaining(['192x192', '512x512']));
+    for (const icon of manifest.icons) {
+      expect(icon.src.startsWith('./')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Related to #436.

Muximux already ships as a PWA (`manifest.json`, maskable icons at 192/256/512, `apple-touch-icon`, `theme-color`, `sw.js`, and registration in `App.svelte` once auth has passed). One thing in it was wrong for anyone not serving from the site root.

## Cause

The manifest is fetched from `./manifest.json`, relative to wherever the SPA is served, and its icon paths are relative, but `start_url` was the absolute `/`. Under a `base_path` such as `/muximux/` that resolves to the site root, which is outside the manifest's implicit scope (its own directory). Browsers refuse to install an app whose start URL is out of scope, so the install prompt never appears there.

## Change

`start_url`, `scope` and `id` are all `./`, so every URL in the manifest resolves against its own location whether that is `/` or `/muximux/`. A test pins the relative form and the installability basics.

Also relevant to #436: install prompts require a secure context, so an instance reached over plain HTTP on a LAN address will never offer installation regardless of the manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Progressive Web App installation and launch behavior when the application is hosted under a base path.
  - Added clearer support for standalone display mode and reliable icon loading during installation.

- **Tests**
  - Added coverage to verify installability settings, relative paths, standalone display behavior, and required icon sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->