### PR TITLE
Build and test on Go 1.27, and cover server.New

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9
@@ -59,6 +60,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.txt ./internal/...
@@ -184,6 +186,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Build frontend
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Build frontend
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,7 +95,7 @@ jobs:
         # (S6386 / "Dependency versions are not predictable") only
         # accepts commit SHAs, not version tags. Bump deliberately
         # via Dependabot or a manual workflow PR.
-        run: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
+        run: go install golang.org/x/vuln/cmd/govulncheck@617f44b718537dccdea1915395650e0529e3b72e # v1.7.0
 
       - name: Run govulncheck
         # This step gates the workflow. It was continue-on-error while

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -87,6 +87,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - name: Install govulncheck
         # SHA-pinned to v1.1.4 (commit d1f3801) so the install is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The primary development environment for Muximux is Claude Code with MCP servers 
 
 ## Prerequisites
 
-- **Go** 1.26+ (check with `go version`)
+- **Go** 1.27+ (check with `go version`)
 - **Node.js** 22+ with npm (check with `node --version`) -- CI and the container build both use Node 26
 - **golangci-lint v2** (`go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`) -- `.golangci.yml` is a v2 config and v1 cannot parse it
 

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,16 @@
 module github.com/mescon/muximux/v3
 
-go 1.26.6
-
-require gopkg.in/yaml.v3 v3.0.1
-
-require github.com/gorilla/websocket v1.5.3
+go 1.27
 
 require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/andybalholm/brotli v1.2.3
 	github.com/caddyserver/caddy/v2 v2.11.4
 	github.com/coreos/go-oidc/v3 v3.20.0
+	github.com/gorilla/websocket v1.5.3
 	golang.org/x/crypto v0.55.0
 	golang.org/x/term v0.45.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/internal/server/new_test.go
+++ b/internal/server/new_test.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/mescon/muximux/v3/internal/config"
+)
+
+// newServerForTest builds a Server through New, exactly as main does, from
+// the default configuration in a scratch data directory. Nothing is started:
+// requests go straight to the assembled handler chain, so the test covers the
+// route table and middleware order without opening a listener.
+func newServerForTest(t *testing.T, mutate func(cfg *config.Config)) *Server {
+	t.Helper()
+	dataDir := t.TempDir()
+	configPath := filepath.Join(dataDir, "config.yaml")
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	cfg.Server.Listen = "127.0.0.1:0"
+	if mutate != nil {
+		mutate(cfg)
+	}
+	s, err := New(cfg, configPath, dataDir, "test", "abcdef0", "2026-01-01")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
+}
+
+func get(t *testing.T, s *Server, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	s.httpServer.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// completeSetup marks the configuration as set up with one builtin admin,
+// so the setup guard steps aside and the real auth middleware is exercised.
+func completeSetup(t *testing.T) func(cfg *config.Config) {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte("correct horse"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	return func(cfg *config.Config) {
+		cfg.Auth.Method = "builtin"
+		cfg.Auth.SetupComplete = true
+		cfg.Auth.Users = []config.UserConfig{{Username: "admin", PasswordHash: string(hash), Role: "admin"}}
+	}
+}
+
+func TestNew_BeforeSetup(t *testing.T) {
+	s := newServerForTest(t, nil)
+
+	t.Run("records build metadata and assembles a handler", func(t *testing.T) {
+		if s.version != "test" || s.commit != "abcdef0" || s.buildDate != "2026-01-01" {
+			t.Fatalf("metadata not stored: %q %q %q", s.version, s.commit, s.buildDate)
+		}
+		if s.httpServer == nil || s.httpServer.Handler == nil {
+			t.Fatal("http server or handler not assembled")
+		}
+	})
+
+	t.Run("mutating api routes are held behind the setup guard", func(t *testing.T) {
+		for _, p := range []string{"/api/apps", "/api/config", "/api/groups"} {
+			rec := get(t, s, p)
+			if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), "setup_required") {
+				t.Errorf("GET %s = %d %q, want 503 setup_required", p, rec.Code, rec.Body.String())
+			}
+		}
+	})
+
+	t.Run("the onboarding wizard's read-only routes stay reachable", func(t *testing.T) {
+		for _, p := range []string{"/api/auth/status", "/api/icons/custom"} {
+			if rec := get(t, s, p); rec.Code != http.StatusOK {
+				t.Errorf("GET %s = %d, want 200", p, rec.Code)
+			}
+		}
+	})
+}
+
+func TestNew_AfterSetup(t *testing.T) {
+	s := newServerForTest(t, completeSetup(t))
+
+	t.Run("api routes require a session", func(t *testing.T) {
+		for _, p := range []string{"/api/apps", "/api/config", "/api/groups", "/api/auth/users"} {
+			if rec := get(t, s, p); rec.Code != http.StatusUnauthorized {
+				t.Errorf("GET %s = %d, want 401", p, rec.Code)
+			}
+		}
+	})
+
+	t.Run("security headers are applied", func(t *testing.T) {
+		rec := get(t, s, "/api/auth/status")
+		for _, h := range []string{"Content-Security-Policy", "X-Content-Type-Options"} {
+			if rec.Header().Get(h) == "" {
+				t.Errorf("missing %s header", h)
+			}
+		}
+	})
+
+	t.Run("encoded dot segments are rejected before auth", func(t *testing.T) {
+		rec := get(t, s, "/api/..%2f..%2fetc/passwd")
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("traversal = %d, want 400", rec.Code)
+		}
+	})
+
+	t.Run("browser-form posts without the CSRF header are refused", func(t *testing.T) {
+		// A CORS-simple content type and no X-Requested-With is exactly what a
+		// cross-origin HTML form can send; the middleware must stop it.
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader("username=admin&password=correct+horse"))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		s.httpServer.Handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("form POST without X-Requested-With = %d, want 403", rec.Code)
+		}
+	})
+
+	t.Run("login with the CSRF header issues a session that unlocks the api", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"username":"admin","password":"correct horse"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Requested-With", "XMLHttpRequest")
+		rec := httptest.NewRecorder()
+		s.httpServer.Handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("login = %d %s", rec.Code, rec.Body.String())
+		}
+		cookies := rec.Result().Cookies()
+		if len(cookies) == 0 {
+			t.Fatal("login set no cookie")
+		}
+		req2 := httptest.NewRequest(http.MethodGet, "/api/apps", nil)
+		for _, c := range cookies {
+			req2.AddCookie(c)
+		}
+		rec2 := httptest.NewRecorder()
+		s.httpServer.Handler.ServeHTTP(rec2, req2)
+		if rec2.Code != http.StatusOK {
+			t.Fatalf("GET /api/apps with session = %d", rec2.Code)
+		}
+	})
+}
+
+func TestNew_BasePath(t *testing.T) {
+	s := newServerForTest(t, func(cfg *config.Config) { cfg.Server.BasePath = "/mux" })
+
+	t.Run("bare base path redirects to the trailing slash", func(t *testing.T) {
+		rec := get(t, s, "/mux")
+		if rec.Code != http.StatusMovedPermanently || rec.Header().Get("Location") != "/mux/" {
+			t.Fatalf("GET /mux = %d %q", rec.Code, rec.Header().Get("Location"))
+		}
+	})
+
+	t.Run("paths outside the base are not found", func(t *testing.T) {
+		if rec := get(t, s, "/other"); rec.Code != http.StatusNotFound {
+			t.Fatalf("GET /other = %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("prefix is stripped before dispatch", func(t *testing.T) {
+		rec := get(t, s, "/mux/api/auth/status")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /mux/api/auth/status = %d, want 200", rec.Code)
+		}
+	})
+}
+
+func TestNew_AuthMethodNone(t *testing.T) {
+	s := newServerForTest(t, func(cfg *config.Config) {
+		cfg.Auth.Method = "none"
+		cfg.Auth.SetupComplete = true
+	})
+	rec := get(t, s, "/api/apps")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/apps with auth none = %d, want 200 (body %q)", rec.Code, rec.Body.String()[:min(80, rec.Body.Len())])
+	}
+}


### PR DESCRIPTION
Four commits, each standing on its own.

## 1. Cover `server.New` through the assembled handler chain

Nothing in the server package tests called `New`, the constructor that registers every route and orders the middleware. Go 1.26's coverage accounting hid that: `internal/server` measured 71.4% there and 56.8% under Go 1.27, which counts the constructor's statements, so the aggregate fell to 84.4% on any machine running 1.27 and the 85% gate failed.

The new tests build a `Server` from the default configuration in a scratch directory and send requests straight to its handler without opening a listener. They pin: the setup guard (mutating routes answer 503 `setup_required` before setup, the onboarding wizard's read-only routes stay open), the authentication requirement after setup, the security headers, rejection of encoded dot segments, CSRF refusal of a browser-form post, a real login issuing a session that then unlocks the API, and `base_path` redirect, 404 and prefix stripping.

Aggregate coverage: **87.3% under Go 1.26.6, 89.7% under Go 1.27.0.**

## 2. Build and test on Go 1.27, tracking the latest patch

`go.mod` pinned an exact patch (1.26.1 until #446, then 1.26.6) and setup-go resolves `go-version-file` to exactly that, so every stdlib fix needed a manual bump before reaching CI or a release; 3.3.3 shipped on 1.26.1 for that reason. The container build already floats on `golang:1.27-alpine` (#438), so CI was validating on a different major than the one that builds releases.

`go 1.27` with no patch is read by the go command as "any 1.27 toolchain" and by setup-go as "the newest 1.27.x"; `check-latest: true` stops runners serving a stale cached patch. CI, the release build and `go.mod` now agree, and future patch releases arrive without a commit.

## 3. Suppress the `Director` deprecation, with reasoning

golangci-lint built with Go 1.27 runs a staticcheck that flags `httputil.ReverseProxy.Director` as deprecated since 1.26 (SA1019). Replacing it with `Rewrite` is not a mechanical swap: with `Director`, `ReverseProxy` appends the client IP to `X-Forwarded-For` itself on top of `setProxyHeaders`, and does so even when `forwarded_headers` is off; `Rewrite` strips inbound `X-Forwarded-*` and adds nothing unless asked. That is a behaviour change for backends and deserves its own tests and release note, so the single site is suppressed with the reasoning inline and the migration tracked separately.

## 4. Bump govulncheck to v1.7.0

The pinned v1.1.4 predates Go 1.27 and panics on its syntax, which would have failed the Security workflow on every run after the toolchain moved. v1.7.0 supports 1.27 and reports no vulnerabilities on this tree.

## Local tooling note

Tools built with Go 1.26 panic in `go/types` when analysing a Go 1.27 standard library, and v1.1.4 govulncheck panics regardless of how it was built. Working versions: `golangci-lint` v2.13.2 and `govulncheck` v1.7.0, both installed with `go install` under Go 1.27 into `$(go env GOPATH)/bin`. The pre-push hook uses whichever is first on `PATH`; on a machine with the distro's golangci-lint in `/usr/bin`, that one wins unless `$(go env GOPATH)/bin` is earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated the project to require Go 1.27.
  - Improved build, test, lint, and release workflows to use the latest compatible Go version.
  - Updated security scanning tooling.

- **Bug Fixes**
  - Added coverage for setup, authentication, CSRF protection, routing, base paths, security headers, and proxy behavior.

- **Documentation**
  - Updated contributor prerequisites to reflect the Go 1.27 requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->