### PR TITLE
Send X-Forwarded-For once, and not at all when forwarding is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Muximux are documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Proxied backends no longer see the client IP twice, and
+  `forwarded_headers: false` now really withholds `X-Forwarded-For`.** The
+  embedding proxy set `X-Forwarded-For` itself and then Go's reverse proxy
+  appended the client address again, so backends received it duplicated;
+  with forwarding switched off the second append still happened, which is
+  exactly the header that made Traefik answer 400. The proxy now uses the
+  reverse proxy's `Rewrite` hook, which adds nothing on its own: the address
+  appears once, an upstream `X-Forwarded-Proto` is preserved, and with
+  forwarding off none of the `X-Forwarded-*` or `X-Real-IP` headers are sent.
 - **Custom uploads work as the overview button icon.** Selecting a custom
   icon for the overview button in General settings appeared to do nothing:
   the card stayed unhighlighted and the navigation kept showing the logo.

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -764,8 +764,28 @@ func buildSingleProxyRoute(app *config.AppConfig, timeout time.Duration, session
 	rewriter := newContentRewriter(proxyPrefix, targetPath, targetURL.Host)
 
 	appName := app.Name
+	forwarded := app.ForwardedOrDefault()
+	director := buildDirector(proxyPrefix, targetPath, targetURL, app.ProxyHeaders, sessionCookieName, forwarded)
 	proxy := &httputil.ReverseProxy{
-		Director:       buildDirector(proxyPrefix, targetPath, targetURL, app.ProxyHeaders, sessionCookieName, app.ForwardedOrDefault()),
+		// Rewrite rather than Director: with Director, ReverseProxy appended
+		// the client IP to X-Forwarded-For itself after setProxyHeaders had
+		// already done so, so backends saw the address twice, and it did so
+		// even with forwarded_headers off, so that option never actually
+		// withheld the header. Rewrite hands us an outbound request with the
+		// inbound X-Forwarded-* removed and adds nothing on its own. When
+		// forwarding is on we carry the inbound chain back over first, so
+		// setProxyHeaders appends exactly once and an upstream proxy's
+		// X-Forwarded-Proto survives; when it is off, nothing is sent.
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			if forwarded {
+				for _, h := range []string{headerXForwardedFor, "X-Forwarded-Host", "X-Forwarded-Proto"} {
+					if v := pr.In.Header.Get(h); v != "" {
+						pr.Out.Header.Set(h, v)
+					}
+				}
+			}
+			director(pr.Out)
+		},
 		ModifyResponse: createModifyResponse(proxyPrefix, targetPath, rewriter), //nolint:bodyclose // response body managed by httputil.ReverseProxy
 		Transport:      transport,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 	"testing"
@@ -603,8 +604,11 @@ func TestDirectorPathMapping(t *testing.T) {
 			// Create a test request
 			req := httptest.NewRequest("GET", tt.requestPath, nil)
 
-			// Apply the director
-			route.proxy.Director(req) //nolint:staticcheck // production still wires Director; test exercises the same field
+			// Drive the proxy's Rewrite the way httputil.ReverseProxy does: the
+			// outbound request is a clone of the inbound one.
+			out := req.Clone(req.Context())
+			route.proxy.Rewrite(&httputil.ProxyRequest{In: req, Out: out})
+			req = out
 
 			// Verify the transformed request
 			if req.URL.Path != tt.expectedPath {
@@ -4063,5 +4067,60 @@ func TestRewriteResponseBody_LayeredEncodingPassThrough(t *testing.T) {
 	got, _ := io.ReadAll(resp.Body)
 	if string(got) != body {
 		t.Errorf("body must be forwarded byte-for-byte")
+	}
+}
+
+// TestReverseProxy_ForwardedHeadersAtBackend checks the headers a backend
+// actually receives, through the real ReverseProxy rather than the director
+// alone. The director-level test above could not see what ReverseProxy added
+// after the director returned, which is how the client IP came to be sent
+// twice and how forwarded_headers: false failed to withhold X-Forwarded-For.
+func TestReverseProxy_ForwardedHeadersAtBackend(t *testing.T) {
+	var got http.Header
+	backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { got = r.Header.Clone() }))
+	defer backend.Close()
+	off := false
+	for _, tc := range []struct {
+		name       string
+		forwarded  *bool
+		inbound    map[string]string
+		wantFor    string
+		wantProto  string
+		wantAbsent bool
+	}{
+		{"on: client ip exactly once", nil, nil, "192.168.1.100", "http", false},
+		{"on: appended once to an inbound chain", nil, map[string]string{"X-Forwarded-For": "1.2.3.4"}, "1.2.3.4, 192.168.1.100", "http", false},
+		{"on: upstream proto survives", nil, map[string]string{"X-Forwarded-Proto": "https"}, "192.168.1.100", "https", false},
+		{"off: nothing forwarded, even with an inbound chain", &off, map[string]string{"X-Forwarded-For": "1.2.3.4", "X-Forwarded-Proto": "https"}, "", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewReverseProxyHandler([]config.AppConfig{{Name: "App", URL: backend.URL, Enabled: true, Proxy: true, ForwardedHeaders: tc.forwarded}}, "30s")
+			req := httptest.NewRequest(http.MethodGet, "/proxy/app/", nil)
+			req.RemoteAddr = "192.168.1.100:12345"
+			for k, v := range tc.inbound {
+				req.Header.Set(k, v)
+			}
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			if tc.wantAbsent {
+				for _, hn := range []string{"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-IP"} {
+					if v := got.Get(hn); v != "" {
+						t.Errorf("%s = %q, want absent with forwarded_headers off", hn, v)
+					}
+				}
+				return
+			}
+			if v := got.Get("X-Forwarded-For"); v != tc.wantFor {
+				t.Errorf("X-Forwarded-For = %q, want %q", v, tc.wantFor)
+			}
+			if v := got.Get("X-Forwarded-Proto"); v != tc.wantProto {
+				t.Errorf("X-Forwarded-Proto = %q, want %q", v, tc.wantProto)
+			}
+			if v := got.Get("X-Real-IP"); v != "192.168.1.100" {
+				t.Errorf("X-Real-IP = %q, want client ip", v)
+			}
+			if v := got.Get("X-Forwarded-Host"); v == "" {
+				t.Error("X-Forwarded-Host missing")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Found while looking at the `Director` deprecation that #448 suppresses. A probe through the real proxy against a recording backend showed what a backend actually receives today:

| Case | `X-Forwarded-For` at the backend |
|---|---|
| forwarded on, no inbound header | `192.168.1.100, 192.168.1.100` |
| forwarded on, inbound `1.2.3.4` | `1.2.3.4, 192.168.1.100, 192.168.1.100` |
| **forwarded off**, inbound `1.2.3.4` | `1.2.3.4, 192.168.1.100` |
| **forwarded off**, no inbound | `192.168.1.100` |

Two defects. `setProxyHeaders` appended the client address in the `Director`, and then `httputil.ReverseProxy` appended it again after the `Director` returned, so backends saw it twice. That second append happened regardless of `forwarded_headers`, so switching forwarding off never withheld `X-Forwarded-For`, which is the header that makes Traefik answer 400 and the reason the option exists. The existing test called the `Director` in isolation and could not see what `ReverseProxy` added afterwards.

## Change

The proxy now uses `ReverseProxy.Rewrite`, which hands over an outbound request with inbound `X-Forwarded-*` removed and adds nothing on its own. With forwarding on, the inbound chain is carried over first so `setProxyHeaders` appends the client exactly once and an upstream `X-Forwarded-Proto` survives. With it off, none of `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto` or `X-Real-IP` are sent. `buildDirector` itself is unchanged; only the adapter around it moved.

This also removes the last use of the deprecated `Director`, so the suppression in #448 can be dropped once this lands.

## Verification

`TestReverseProxy_ForwardedHeadersAtBackend` observes headers at a real backend through `NewReverseProxyHandler`. As a negative control it was run against the previous code and fails in all four cases with exactly the values in the table above. Full handlers suite, vet, and golangci-lint under both the Go 1.26 and 1.27 toolchains are clean, with no `staticcheck` SA1019 remaining.

Behaviour change for operators: backends that parsed the last entry of `X-Forwarded-For` were already getting the right address; backends that counted hops will now see one fewer. Noted in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed forwarded-header handling for proxy requests.
  * Client information is no longer duplicated in `X-Forwarded-For`.
  * Preserved upstream protocol information when header forwarding is enabled.
  * Prevented forwarding of `X-Forwarded-*` and `X-Real-IP` headers when forwarding is disabled, avoiding related proxy errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->