### PR TITLE
Rewrite import maps and drop Mealie's embedding hint in the proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ offered. Drop-in.
   Display in the app form or with `pinned: true` in `config.yaml`. (#444)
 
 ### Fixed
+- **Mealie 3.24+ (Nuxt 4.5) loads through the proxy again.** Nuxt 4.5 boots
+  its entry module from an inline import map
+  (`{"imports":{"#entry":"/_nuxt/....js"}}`) and loads it with
+  `import("#entry")`, which the browser's module loader resolves without ever
+  touching the runtime interceptor. The rewriter deliberately leaves JSON in
+  HTML alone, so the entry URL stayed root-relative, 404ed at the dashboard,
+  and the proxied page rendered blank. Import maps are now the one JSON
+  block that is rewritten: root-relative `imports` and `scopes` values get
+  the proxy prefix, everything else is left as is. (#270)
+- **Mealie 3.25 login works inside the proxied frame.** Mealie's new auth
+  sends `X-Mealie-Embedded: true` from any frame and then asks for a
+  `Partitioned` cookie, which its Python 3.12 image cannot produce, so every
+  login from a frame over HTTPS answered 500. A proxied frame is same-origin
+  with the dashboard and needs no cross-site cookie handling, so the proxy
+  now drops that hint and Mealie issues an ordinary `SameSite=Lax` cookie.
+  Loaded directly in an iframe without the proxy, the 500 is Mealie's to fix.
+  (#270)
 - **Proxied backends no longer see the client IP twice, and
   `forwarded_headers: false` now really withholds `X-Forwarded-For`.** The
   embedding proxy set `X-Forwarded-For` itself and then Go's reverse proxy

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"html"
 	"io"
@@ -206,7 +207,96 @@ func (r *contentRewriter) rewrite(content []byte) []byte {
 	content = r.rewriteSVGHrefs(content)
 	content = r.rewriteMetaRefresh(content)
 	content = r.rewriteModuleImports(content)
+	content = r.rewriteImportMap(content)
 	return content
+}
+
+// importMapPattern matches an inline <script type="importmap"> block. Nuxt 4.5
+// boots through one ({"imports":{"#entry":"/_nuxt/<hash>.js"}}), loading the
+// entry with import("#entry"), so the browser's module loader resolves the
+// bare specifier from this map without ever consulting the runtime
+// interceptor.
+var importMapPattern = regexp.MustCompile(`(?is)(<script[^>]*\btype\s*=\s*["']importmap["'][^>]*>)(.*?)(</script>)`)
+
+// rewriteImportMap prefixes root-relative module URLs inside import maps.
+// This is the one place JSON in HTML is rewritten on purpose: an import map
+// holds nothing but module URLs for the browser's loader, which bypasses
+// fetch/XHR interception, so leaving "/_nuxt/entry.js" unprefixed sends the
+// request to the dashboard's own origin and the app never starts. Relative
+// and bare specifiers are left alone; a map that does not parse is returned
+// untouched rather than risk corrupting it.
+func (r *contentRewriter) rewriteImportMap(content []byte) []byte {
+	if !bytes.Contains(bytes.ToLower(content), []byte("importmap")) {
+		return content
+	}
+	return importMapPattern.ReplaceAllFunc(content, func(match []byte) []byte {
+		sub := importMapPattern.FindSubmatch(match)
+		if sub == nil {
+			return match
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(bytes.TrimSpace(sub[2]), &m); err != nil {
+			return match
+		}
+		changed := false
+		if raw, ok := m["imports"]; ok {
+			if out, c := r.rewriteImportMapEntries(raw); c {
+				m["imports"], changed = out, true
+			}
+		}
+		if raw, ok := m["scopes"]; ok {
+			var scopes map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &scopes); err == nil {
+				scopeChanged := false
+				for k, v := range scopes {
+					if out, c := r.rewriteImportMapEntries(v); c {
+						scopes[k], scopeChanged = out, true
+					}
+				}
+				if scopeChanged {
+					if enc, err := json.Marshal(scopes); err == nil {
+						m["scopes"], changed = enc, true
+					}
+				}
+			}
+		}
+		if !changed {
+			return match
+		}
+		enc, err := json.Marshal(m)
+		if err != nil {
+			return match
+		}
+		out := make([]byte, 0, len(sub[1])+len(enc)+len(sub[3]))
+		out = append(out, sub[1]...)
+		out = append(out, enc...)
+		out = append(out, sub[3]...)
+		return out
+	})
+}
+
+// rewriteImportMapEntries prefixes the root-relative values of one
+// specifier map. It reports whether anything changed.
+func (r *contentRewriter) rewriteImportMapEntries(raw json.RawMessage) (json.RawMessage, bool) {
+	var entries map[string]string
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return raw, false
+	}
+	changed := false
+	for k, v := range entries {
+		if strings.HasPrefix(v, "/") && !strings.HasPrefix(v, "//") && !strings.HasPrefix(v, r.proxyPrefix+"/") && v != r.proxyPrefix {
+			entries[k] = r.proxyPrefix + v
+			changed = true
+		}
+	}
+	if !changed {
+		return raw, false
+	}
+	enc, err := json.Marshal(entries)
+	if err != nil {
+		return raw, false
+	}
+	return enc, true
 }
 
 // rewriteScript performs URL rewriting for JavaScript/JSON content.
@@ -902,6 +992,14 @@ func buildDirector(proxyPrefix, targetPath string, targetURL *url.URL, customHea
 			setProxyHeaders(req)
 		}
 		stripSessionCookie(req, sessionCookieName)
+		// A proxied app is same-origin with the dashboard, so cookie mitigations
+		// for cross-site framing (SameSite=None, Partitioned) are unnecessary and
+		// counterproductive: Mealie 3.25 sends this hint from any frame and then
+		// asks Starlette for a partitioned cookie, which its Python 3.12 image
+		// cannot produce, so every login from a frame over HTTPS answered 500.
+		// Without the hint it issues an ordinary SameSite=Lax cookie, which is
+		// exactly right for a first-party frame.
+		req.Header.Del("X-Mealie-Embedded")
 
 		// Inject per-app custom headers (e.g., Authorization, X-Api-Key).
 		// Values may reference the authenticated user via ${user}/${role}/

--- a/internal/handlers/reverse_proxy.go
+++ b/internal/handlers/reverse_proxy.go
@@ -267,11 +267,7 @@ func (r *contentRewriter) rewriteImportMap(content []byte) []byte {
 		if err != nil {
 			return match
 		}
-		out := make([]byte, 0, len(sub[1])+len(enc)+len(sub[3]))
-		out = append(out, sub[1]...)
-		out = append(out, enc...)
-		out = append(out, sub[3]...)
-		return out
+		return bytes.Join([][]byte{sub[1], enc, sub[3]}, nil)
 	})
 }
 

--- a/internal/handlers/reverse_proxy_test.go
+++ b/internal/handlers/reverse_proxy_test.go
@@ -4124,3 +4124,75 @@ func TestReverseProxy_ForwardedHeadersAtBackend(t *testing.T) {
 		})
 	}
 }
+
+// TestRewriteImportMap covers the Nuxt 4.5 boot path: the entry module is
+// referenced only from an inline import map and loaded with import("#entry"),
+// which the module loader resolves without touching fetch/XHR interception.
+func TestRewriteImportMap(t *testing.T) {
+	rw := newContentRewriter("/proxy/mealie", "", "")
+	tests := []struct {
+		name, input, want string
+	}{
+		{
+			name:  "nuxt entry map is prefixed",
+			input: `<script type="importmap">{"imports":{"#entry":"/_nuxt/Df1JahhX.js"}}</script>`,
+			want:  `<script type="importmap">{"imports":{"#entry":"/proxy/mealie/_nuxt/Df1JahhX.js"}}</script>`,
+		},
+		{
+			name:  "scopes are prefixed too",
+			input: `<script type="importmap">{"imports":{"a":"/a.js"},"scopes":{"/admin/":{"b":"/b.js"}}}</script>`,
+			want:  `<script type="importmap">{"imports":{"a":"/proxy/mealie/a.js"},"scopes":{"/admin/":{"b":"/proxy/mealie/b.js"}}}</script>`,
+		},
+		{
+			name:  "relative, bare and protocol-relative specifiers are untouched",
+			input: `<script type="importmap">{"imports":{"vue":"./vue.js","lodash":"https://cdn.example/lodash.js","x":"//cdn.example/x.js","bare":"react"}}</script>`,
+			want:  `<script type="importmap">{"imports":{"vue":"./vue.js","lodash":"https://cdn.example/lodash.js","x":"//cdn.example/x.js","bare":"react"}}</script>`,
+		},
+		{
+			name:  "already prefixed values are not doubled",
+			input: `<script type="importmap">{"imports":{"#entry":"/proxy/mealie/_nuxt/e.js"}}</script>`,
+			want:  `<script type="importmap">{"imports":{"#entry":"/proxy/mealie/_nuxt/e.js"}}</script>`,
+		},
+		{
+			name:  "attributes in any order and single quotes",
+			input: `<script nonce="abc" type='importmap'>{"imports":{"#entry":"/e.js"}}</script>`,
+			want:  `<script nonce="abc" type='importmap'>{"imports":{"#entry":"/proxy/mealie/e.js"}}</script>`,
+		},
+		{
+			name:  "malformed json is left alone",
+			input: `<script type="importmap">{"imports":{"#entry":"/e.js"</script>`,
+			want:  `<script type="importmap">{"imports":{"#entry":"/e.js"</script>`,
+		},
+		{
+			name:  "ordinary inline json payloads are not rewritten",
+			input: `<script>window.__NUXT__={"path":"/recipe/1"}</script>`,
+			want:  `<script>window.__NUXT__={"path":"/recipe/1"}</script>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(rw.rewrite([]byte(tt.input))); got != tt.want {
+				t.Errorf("\n got: %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDirector_DropsEmbeddingHint: a proxied frame is first-party, so the
+// backend must not be told it is embedded (Mealie 3.25 answers 500 to that
+// over HTTPS on its Python 3.12 image, and would otherwise issue a
+// SameSite=None cookie that is pointless for a same-origin frame).
+func TestDirector_DropsEmbeddingHint(t *testing.T) {
+	target, _ := url.Parse("http://mealie.local:9000")
+	director := buildDirector("/proxy/mealie", "", target, nil, "muximux_session", true)
+	req := httptest.NewRequest(http.MethodPost, "/proxy/mealie/api/auth/token", nil)
+	req.Header.Set("X-Mealie-Embedded", "true")
+	req.Header.Set("X-Custom-Kept", "yes")
+	director(req)
+	if v := req.Header.Get("X-Mealie-Embedded"); v != "" {
+		t.Errorf("X-Mealie-Embedded forwarded as %q, want dropped", v)
+	}
+	if v := req.Header.Get("X-Custom-Kept"); v != "yes" {
+		t.Errorf("unrelated header lost: %q", v)
+	}
+}


### PR DESCRIPTION
Refs #270. Mealie 3.25.0 stopped working through the proxy for two independent reasons, one ours and one theirs, both reproduced against a clean Mealie 3.25.0 container.

## 1. Ours: Nuxt 4.5 boots from an import map the rewriter ignored

Nuxt 4.5 (Mealie 3.24+) emits `<script type="importmap">{"imports":{"#entry":"/_nuxt/<hash>.js"}}</script>` and loads the entry with `import("#entry")`. The browser's module loader resolves that from the map without touching fetch or XHR, and the rewriter deliberately leaves JSON in HTML alone (SSR payloads must not be rewritten). So the entry URL stayed root-relative, 404ed at the dashboard, and the proxied page rendered blank with `NUXT_E1005` in the console.

Import maps hold nothing but module URLs, so they become the one JSON block that is rewritten: root-relative `imports` and `scopes` values get the proxy prefix; relative, bare, protocol-relative and absolute specifiers are untouched; a map that does not parse is left as is.

## 2. Theirs: the embedded-cookie path crashes on their Python

Mealie 3.25's auth overhaul sends `X-Mealie-Embedded: true` from any frame (`window.self !== window.top`) and, over HTTPS, asks Starlette for a `Partitioned` cookie. Starlette raises `ValueError: Partitioned cookies are only supported in Python 3.14 and above` and the image ships Python 3.12.13, so every login from a frame over HTTPS answers 500. Reproduced with curl against the container: top-level login 200, the same request with the hint plus `X-Forwarded-Proto: https` 500.

A proxied frame is same-origin with the dashboard and needs no cross-site cookie handling, so the director drops the hint and Mealie issues an ordinary `SameSite=Lax` cookie, which is exactly right for a first-party frame. Loaded directly in an iframe without the proxy, the 500 remains Mealie's to fix.

## Verification

Headless Chromium against a built binary with Mealie 3.25.0 proxied and `X-Forwarded-Proto: https` injected to simulate TLS termination:

- previous build: frame blank, `Failed to fetch dynamically imported module .../_nuxt/....js`, 0 inputs after 20 s
- this branch: frame renders `/proxy/mealie/login` with the form, the browser still sends the hint, `POST /proxy/mealie/api/auth/token` answers **200**, and the frame lands on the post-login admin setup page

Unit tests cover the import-map cases (entry, scopes, untouched specifiers, already-prefixed, malformed, and that ordinary inline JSON payloads stay untouched) and the header drop. Full handlers suite, vet and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed import-map URL resolution for proxied Mealie instances running Nuxt 4.5.
  - Improved login behavior for proxied Mealie 3.25 frames by enabling standard `SameSite=Lax` cookie handling.
  - Removed the embedded-mode hint from proxied requests to prevent incorrect authentication behavior.
  - Preserved relative, external, and already-prefixed import-map URLs while updating only applicable root-relative paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->