### PR TITLE
Project single-app reads for the caller's role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Muximux are documented in this file.
 
+## [Unreleased]
+
+### Security
+- **A non-admin user could read any app's full configuration.** `GET
+  /api/app/{name}` used the administrative projection for every caller and
+  skipped the visibility rules the list endpoint applies, so any signed-in
+  user could retrieve `proxy_headers`, `http_action_headers`,
+  `docker_endpoint` and credentials embedded in an app's URL, and could
+  fetch apps hidden from them by `min_role` or `allowed_groups`. The
+  endpoint now projects for the caller's role through the same rule as
+  `/api/apps` and answers 404 for anything the caller could not list.
+  Reported privately by zjh777. (GHSA-44h2-562r-3m67)
+
 ## [3.4.0] - 2026-09-03
 
 A security release with one feature. The 3.3.x binaries were built on a Go

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -645,16 +645,30 @@ func (h *APIHandler) GetGroups(w http.ResponseWriter, r *http.Request) {
 	sendJSON(w, http.StatusOK, h.config.Groups)
 }
 
-// GetApp returns a single app by name
+// GetApp returns a single app by name, projected for the caller's role and
+// subject to the same visibility rules as the list: an app the caller could
+// not see in /api/apps answers 404 here too, so the endpoint cannot be used
+// to probe for admin-only apps, and non-admins never receive proxy headers,
+// action headers or URL credentials (GHSA-44h2-562r-3m67).
 func (h *APIHandler) GetApp(w http.ResponseWriter, r *http.Request, name string) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
+	userRole, userGroups := getUserRoleAndGroups(r)
+	isAdmin := isAdminRole(userRole)
 	for i := range h.config.Apps {
-		if h.config.Apps[i].Name == name {
-			sendJSON(w, http.StatusOK, sanitizeApp(&h.config.Apps[i]))
-			return
+		if h.config.Apps[i].Name != name {
+			continue
 		}
+		if !appVisibleTo(&h.config.Apps[i], userRole, userGroups) {
+			break
+		}
+		client := sanitizeAppForRole(&h.config.Apps[i], isAdmin)
+		if d, ok := gatewayDomainsByAppName(h.config.Server.GatewaySites)[name]; ok {
+			client.GatewayDomain = d
+		}
+		sendJSON(w, http.StatusOK, client)
+		return
 	}
 
 	respondError(w, r, http.StatusNotFound, errAppNotFound)
@@ -1194,38 +1208,42 @@ type ClientAppConfig struct {
 // configured gateway-sites list; any site whose AppName matches an
 // app surfaces as ClientAppConfig.GatewayDomain so the App form can
 // show the "Hosted by Muximux gateway" badge.
+// isAdminRole reports whether a role gets the administrative projection.
+// The empty role means no authenticated user (auth disabled or the setup
+// preview), which has always been treated as admin here.
+func isAdminRole(userRole string) bool {
+	return userRole == "" || userRole == auth.RoleAdmin
+}
+
+// appVisibleTo is the single visibility rule for apps, shared by the list
+// and single-app endpoints so they can never disagree about what a caller
+// may see. Admins see every app, disabled ones included, because they
+// manage them in Settings and a save that round-trips a filtered list would
+// silently delete the rest. Non-admins see enabled apps that pass the
+// app's min_role and, when it declares one, its allowed_groups list
+// (case-insensitive, matching the admin-group check elsewhere). The empty
+// role disables both gates so the setup preview sees everything.
+func appVisibleTo(app *config.AppConfig, userRole string, userGroups []string) bool {
+	isAdmin := isAdminRole(userRole)
+	if !isAdmin && !app.Enabled {
+		return false
+	}
+	if userRole != "" && app.MinRole != "" && !auth.HasMinRole(userRole, app.MinRole) {
+		return false
+	}
+	if userRole != "" && !isAdmin && len(app.AllowedGroups) > 0 && !userInAnyAllowedGroup(userGroups, app.AllowedGroups) {
+		return false
+	}
+	return true
+}
+
 func sanitizeApps(apps []config.AppConfig, userRole string, userGroups []string, gatewaySites []config.GatewaySite) []ClientAppConfig {
-	isAdmin := userRole == "" || userRole == auth.RoleAdmin
+	isAdmin := isAdminRole(userRole)
 	domains := gatewayDomainsByAppName(gatewaySites)
 	result := make([]ClientAppConfig, 0, len(apps))
 	for i := range apps {
-		// Admins see all apps including disabled ones - they need to
-		// manage them in the Settings UI, and any save path that
-		// round-trips a sanitised /api/config response would otherwise
-		// silently delete every disabled app the operator configured.
-		// Non-admins only see enabled apps (disabled = hidden from
-		// their menu, matching the nav-bar's own filtering).
-		if !isAdmin && !apps[i].Enabled {
+		if !appVisibleTo(&apps[i], userRole, userGroups) {
 			continue
-		}
-		// Filter by minimum role if a user role is provided.
-		if userRole != "" && apps[i].MinRole != "" {
-			if !auth.HasMinRole(userRole, apps[i].MinRole) {
-				continue
-			}
-		}
-		// Filter by group membership when the app declares an
-		// allowed_groups list. Empty list = no group gate. Matching is
-		// case-insensitive to mirror the admin-group check elsewhere.
-		// Admins bypass the group gate the same way they bypass min_role
-		// in HasMinRole, so an operator can still see every app even
-		// from a personal account that isn't in any IdP group.
-		// userRole == "" disables the group check too so unauth setup
-		// previews still see every app, matching the role behaviour.
-		if userRole != "" && !isAdmin && len(apps[i].AllowedGroups) > 0 {
-			if !userInAnyAllowedGroup(userGroups, apps[i].AllowedGroups) {
-				continue
-			}
 		}
 		client := sanitizeAppForRole(&apps[i], isAdmin)
 		if d, ok := domains[apps[i].Name]; ok {

--- a/internal/handlers/api_test.go
+++ b/internal/handlers/api_test.go
@@ -2997,3 +2997,82 @@ func TestExportConfig_NoRaceWithConcurrentAppMutation(t *testing.T) {
 	}
 	<-done
 }
+
+// TestGetApp_ProjectsForCallerRole is the regression test for
+// GHSA-44h2-562r-3m67: the single-app endpoint used the admin projection for
+// everyone and skipped the visibility rules, so a plain user could read proxy
+// headers, action headers, URL credentials, and admin-only apps that the list
+// endpoint correctly withheld.
+func TestGetApp_ProjectsForCallerRole(t *testing.T) {
+	cfg := &config.Config{Apps: []config.AppConfig{
+		{Name: "Sonarr", URL: "http://svc:secretpass@sonarr.local:8989", Enabled: true, Proxy: true, ProxyHeaders: map[string]string{"X-Api-Key": "sonarr-key"}}, //nolint:gosec // fixture: the leak of exactly this credential is what the test detects
+		{Name: "Webhook", URL: "http://hooks.local/fire", Enabled: true, OpenMode: "http_action", HTTPActionMethod: "POST", HTTPActionHeaders: map[string]string{"X-Webhook-Token": "whsec_abc"}},
+		{Name: "AdminOnly", URL: "http://admin-only.local", Enabled: true, MinRole: "admin"},
+		{Name: "OpsOnly", URL: "http://ops.local", Enabled: true, AllowedGroups: []string{"ops"}},
+		{Name: "Disabled", URL: "http://off.local", Enabled: false},
+	}}
+	handler := NewAPIHandler(cfg, "/dev/null/impossible", &sync.RWMutex{})
+	get := func(name string, user *auth.User) (int, ClientAppConfig) {
+		req := httptest.NewRequest(http.MethodGet, "/api/app/"+name, nil)
+		if user != nil {
+			req = req.WithContext(auth.WithUserContext(req.Context(), user))
+		}
+		w := httptest.NewRecorder()
+		handler.GetApp(w, req, name)
+		var out ClientAppConfig
+		if w.Code == http.StatusOK {
+			if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+		}
+		return w.Code, out
+	}
+	viewer := &auth.User{Username: "viewer", Role: "user"}
+	opsUser := &auth.User{Username: "ops", Role: "user", Groups: []string{"Ops"}}
+	admin := &auth.User{Username: "admin", Role: auth.RoleAdmin}
+
+	t.Run("user gets a redacted projection", func(t *testing.T) {
+		code, app := get("Sonarr", viewer)
+		if code != http.StatusOK {
+			t.Fatalf("code = %d", code)
+		}
+		if app.URL != "http://sonarr.local:8989" {
+			t.Errorf("url leaked credentials: %q", app.URL)
+		}
+		if len(app.ProxyHeaders) != 0 {
+			t.Errorf("proxy_headers leaked: %v", app.ProxyHeaders)
+		}
+		code, app = get("Webhook", viewer)
+		if code != http.StatusOK || len(app.HTTPActionHeaders) != 0 {
+			t.Errorf("http_action_headers leaked (code %d): %v", code, app.HTTPActionHeaders)
+		}
+	})
+	t.Run("user cannot see apps the list withholds", func(t *testing.T) {
+		for _, name := range []string{"AdminOnly", "OpsOnly", "Disabled"} {
+			if code, _ := get(name, viewer); code != http.StatusNotFound {
+				t.Errorf("GET %s as user = %d, want 404", name, code)
+			}
+		}
+	})
+	t.Run("group membership opens a group-gated app", func(t *testing.T) {
+		if code, _ := get("OpsOnly", opsUser); code != http.StatusOK {
+			t.Errorf("GET OpsOnly as ops member = %d, want 200", code)
+		}
+	})
+	t.Run("admin still sees everything", func(t *testing.T) {
+		code, app := get("Sonarr", admin)
+		if code != http.StatusOK || app.ProxyHeaders["X-Api-Key"] != "sonarr-key" || app.URL != "http://svc:secretpass@sonarr.local:8989" { //nolint:gosec // fixture credential, see above
+			t.Errorf("admin projection lost fields (code %d): %+v", code, app)
+		}
+		for _, name := range []string{"AdminOnly", "OpsOnly", "Disabled"} {
+			if code, _ := get(name, admin); code != http.StatusOK {
+				t.Errorf("GET %s as admin = %d, want 200", name, code)
+			}
+		}
+	})
+	t.Run("unknown app is still 404", func(t *testing.T) {
+		if code, _ := get("Nope", viewer); code != http.StatusNotFound {
+			t.Errorf("code = %d", code)
+		}
+	})
+}


### PR DESCRIPTION
Fixes the authorization gap reported privately as GHSA-44h2-562r-3m67.

`GET /api/app/{name}` handed every caller the administrative projection (`sanitizeApp` is `sanitizeAppForRole(app, true)`) and skipped the visibility rules that `/api/apps` applies. Verified against the 3.4.0 release with a `user`-role account:

| Endpoint | URL with credentials | `proxy_headers` | `http_action_headers` | app with `min_role: admin` |
|---|---|---|---|---|
| `GET /api/apps` | stripped | hidden | hidden | not listed |
| `GET /api/app/{name}` before | **returned** | **returned** | **returned** | **200** |
| `GET /api/app/{name}` after | stripped | hidden | hidden | 404 |

## Change

- The visibility rule (enabled, `min_role`, `allowed_groups`, admin bypass) moves out of `sanitizeApps` into `appVisibleTo`, so the list and single-app endpoints share one definition and cannot drift again.
- `GetApp` projects with `sanitizeAppForRole` for the caller's role, attaches the gateway domain the way the list does, and answers 404 for anything the caller could not list, so the endpoint cannot be used to probe for hidden apps.
- Admin responses are unchanged.

## Audit of siblings

`/api/config` already projects by role, gateway sites are admin-only, and groups carry no sensitive fields. This endpoint was the only gap.

## Tests

`TestGetApp_ProjectsForCallerRole`: user gets redacted URL and no headers; user gets 404 for admin-only, group-gated and disabled apps; a group member can read a group-gated app; admin still sees everything; unknown app is 404. Full handlers and server suites, vet and lint clean. Also verified end to end against a rebuilt binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved access controls for individual app requests.
  - Users now receive only the app details permitted by their role and group membership.
  - Restricted apps, disabled apps, and apps outside a user’s visibility return a not-found response.
  - Sensitive information, including URL credentials and internal headers, is no longer exposed to non-admin users.
  - Administrators retain full access to permitted app details.
- **Bug Fixes**
  - Individual app responses now follow the same visibility rules as app listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->