### PR TITLE
Reject base paths that would turn the trailing-slash redirect into an open redirect

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,17 +347,42 @@ type ServerConfig struct {
 	SessionCookieDomain string `yaml:"session_cookie_domain,omitempty" json:"session_cookie_domain,omitempty"`
 }
 
+// validateBasePath rejects base paths that could not be served as a plain
+// URL prefix: a protocol-relative "//host" (an open redirect once the bare
+// path is redirected to its trailing-slash form), backslashes, dot segments,
+// whitespace, and query or fragment characters.
+func validateBasePath(bp string) error {
+	if bp == "" {
+		return nil
+	}
+	if strings.HasPrefix(bp, "//") {
+		return fmt.Errorf("server.base_path %q must not start with \"//\"", bp)
+	}
+	if strings.ContainsAny(bp, "\\?#") || strings.ContainsAny(bp, " \t\r\n") {
+		return fmt.Errorf("server.base_path %q must be a plain path without \\, ?, # or whitespace", bp)
+	}
+	for _, seg := range strings.Split(bp, "/") {
+		if seg == "." || seg == ".." {
+			return fmt.Errorf("server.base_path %q must not contain dot segments", bp)
+		}
+	}
+	return nil
+}
+
 // NormalizedBasePath returns the base path with a leading slash and no trailing slash.
 // Returns "" if no base path is configured.
 func (c *ServerConfig) NormalizedBasePath() string {
+	// Collapse any run of leading slashes to one: a base path of "//host"
+	// would otherwise become the protocol-relative redirect target
+	// "//host/" in the bare-base-path redirect, an open redirect to
+	// another site. validate() rejects such values up front; this keeps
+	// the redirect safe even for a config that bypassed validation.
 	p := strings.TrimRight(c.BasePath, "/")
+	p = strings.TrimLeft(p, "/")
 	if p == "" {
 		return ""
 	}
-	if !strings.HasPrefix(p, "/") {
-		p = "/" + p
-	}
-	return p
+	return "/" + p
 }
 
 // NeedsCaddy returns true if TLS, the legacy gateway file, or any
@@ -840,6 +865,9 @@ func (c *Config) Validate() error {
 
 // validate checks the configuration for contradictory or incomplete settings.
 func (c *Config) validate() error {
+	if err := validateBasePath(c.Server.BasePath); err != nil {
+		return err
+	}
 	tls := c.Server.TLS
 
 	if tls.Domain != "" && tls.Email == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2025,3 +2025,30 @@ func TestLoad_PinnedApp(t *testing.T) {
 		t.Errorf("expected exactly one pinned: line on save (omitempty), got %d in:\n%s", got, out)
 	}
 }
+
+// TestBasePathValidation pins the base_path rules that keep the bare-path
+// redirect (basePath -> basePath + "/") from becoming an open redirect, and
+// the normaliser's defence in depth for the same case.
+func TestBasePathValidation(t *testing.T) {
+	for _, bp := range []string{"", "/muximux", "muximux", "/a/b", "/mux/"} {
+		if err := validateBasePath(bp); err != nil {
+			t.Errorf("base_path %q rejected: %v", bp, err)
+		}
+	}
+	for _, bp := range []string{"//evil.example", "///evil.example", "/mux\\x", "/a/../b", "/./a", "/a?b", "/a#b", "/a b"} {
+		if err := validateBasePath(bp); err == nil {
+			t.Errorf("base_path %q accepted, want error", bp)
+		}
+	}
+	for in, want := range map[string]string{"": "", "/muximux": "/muximux", "muximux": "/muximux", "/mux/": "/mux", "//evil.example": "/evil.example", "///x": "/x"} {
+		s := ServerConfig{BasePath: in}
+		if got := s.NormalizedBasePath(); got != want {
+			t.Errorf("NormalizedBasePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+	cfg := defaultConfig()
+	cfg.Server.BasePath = "//evil.example"
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate accepted a protocol-relative base_path")
+	}
+}


### PR DESCRIPTION
Closes the one CodeQL finding left open after triage (#34, `go/bad-redirect-check`, `NormalizedBasePath`).

The bare base path is redirected to its trailing-slash form, so a `base_path` of `//host` produced the protocol-relative `Location: //host/`, a redirect to another site. Only an administrator can set `base_path`, which is why this was a code-scanning finding rather than a reported vulnerability, but it is cheap to close for good.

## Change

- `validateBasePath` runs at config load: no leading `//`, no backslashes, whitespace, `?` or `#`, and no `.`/`..` segments.
- `NormalizedBasePath` collapses any run of leading slashes to one, so the redirect stays safe even for a config that bypassed validation.
- Tests cover accepted and rejected values, normalisation, and `Validate()` refusing a protocol-relative path.

## Triage of the other 14 alerts

Dismissed with rationale on each alert: API-key hashing is SHA-256 over server-generated 256-bit tokens by design (bcrypt there was an unauthenticated CPU-amplification vector); the Docker endpoint and TLS file paths are operator configuration, not request input; the icon fetch is admin-only behind `validateHostSSRF` on every hop; and the theme name passes `sanitizeThemeID` (`[a-z0-9-]` only) before any filesystem use. The clear-text-logging hit logs a username at debug level, not a credential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for server base paths, rejecting unsafe formats such as protocol-relative URLs, traversal segments, backslashes, whitespace, queries, and fragments.
  - Prevented malformed base paths from creating unintended redirects.
  - Normalized paths with multiple leading slashes to a single leading slash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->